### PR TITLE
Add Access Token Service

### DIFF
--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/AuthCookieManagerTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/AuthCookieManagerTests.cs
@@ -133,6 +133,78 @@ public class AuthCookieManagerTests
         ValidateCookie("test.example", cookies[1]);
     }
     
+    [Fact]
+    public void GetCookieValueForCustomer_Null_IfNoCookies()
+    {
+        // Arrange
+        var sut = GetSut();
+        
+        // Act
+        var cookieValue = sut.GetCookieValueForCustomer(123);
+        
+        // Assert
+        cookieValue.Should().BeNull();
+    }
+    
+    [Fact]
+    public void GetCookieValueForCustomer_Null_IfNoCookieForDifferentCustomer()
+    {
+        // Arrange
+        var sut = GetSut();
+        request.Headers.Append("Cookie", "auth-token-999=whatever");
+
+        // Act
+        var cookieValue = sut.GetCookieValueForCustomer(123);
+        
+        // Assert
+        cookieValue.Should().BeNull();
+    }
+    
+    [Fact]
+    public void GetCookieValueForCustomer_ReturnsCookieValue_IfFound()
+    {
+        // Arrange
+        var sut = GetSut();
+        request.Headers.Append("Cookie", "auth-token-123=whatever");
+
+        // Act
+        var cookieValue = sut.GetCookieValueForCustomer(123);
+        
+        // Assert
+        cookieValue.Should().Be("whatever");
+    }
+    
+    [Fact]
+    public void GetCookieIdFromValue_ReturnsExpected()
+    {
+        // Arrange
+        const string cookieValue = "id=1212121212";
+        const string expected = "1212121212";
+        
+        var sut = GetSut();
+
+        // Act
+        var actual = sut.GetCookieIdFromValue(cookieValue);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetCookieIdFromValue_Null_IfCookiesDoesNotStartAsExpected()
+    {
+        // Arrange
+        const string cookieValue = "121id=2121212";
+
+        var sut = GetSut();
+
+        // Act
+        var actual = sut.GetCookieIdFromValue(cookieValue);
+
+        // Assert
+        actual.Should().BeNull();
+    }
+    
     private AuthCookieManager GetSut(bool useCurrentDomainForCookie = true, params string[] additionalDomains)
     {
         var options = Options.Create(new AuthSettings

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessServiceTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessServiceTests.cs
@@ -92,6 +92,7 @@ public class AccessServiceTests : IClassFixture<AuthWebApplicationFactory>
 
         var token = await dbContext.RoleProvisionTokens.SingleAsync(t => t.Id == hiddenValue);
         token.Roles.Should().ContainSingle(DatabaseFixture.ClickthroughRoleUri);
+        token.Origin.Should().Be("http://whatever.here/");
         token.Used.Should().BeFalse();
     }
     
@@ -287,6 +288,7 @@ public class AccessServiceTests : IClassFixture<AuthWebApplicationFactory>
         authToken.Expires.Should().NotBeBefore(DateTime.UtcNow);
         authToken.Customer.Should().Be(99);
         authToken.Roles.Should().BeEquivalentTo(roles);
+        authToken.Origin.Should().Be("http://localhost");
         
         await dbContext.Entry(tokenEntity.Entity).ReloadAsync();
         tokenEntity.Entity.Used.Should().BeTrue("token is now used");
@@ -304,5 +306,9 @@ public class AccessServiceTests : IClassFixture<AuthWebApplicationFactory>
     }
 
     private static RoleProvisionToken CreateToken(string token, bool used, string[] roles)
-        => new() { Id = token, Created = DateTime.UtcNow, Customer = 99, Roles = roles.ToList(), Used = used };
+        => new()
+        {
+            Id = token, Created = DateTime.UtcNow, Customer = 99, Roles = roles.ToList(), Used = used,
+            Origin = "http://localhost"
+        };
 }

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessTokenServiceTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessTokenServiceTests.cs
@@ -251,7 +251,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
         
         // Assert
         await dbContext.Entry(sessionUser.Entity).ReloadAsync();
-        sessionUser.Entity.LastChecked.Should().Be(lastChecked);
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(lastChecked, TimeSpan.FromMilliseconds(100));
     }
 
     private static async Task ValidateResponse(HttpResponseMessage response, string? expectedProfile = null,

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessTokenServiceTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessTokenServiceTests.cs
@@ -1,0 +1,295 @@
+﻿using System.Net;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+using IIIFAuth2.API.Data;
+using IIIFAuth2.API.Data.Entities;
+using IIIFAuth2.API.Tests.TestingInfrastructure;
+
+namespace IIIFAuth2.API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(DatabaseCollection.CollectionName)]
+public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
+{
+    private readonly HttpClient httpClient;
+    private readonly AuthServicesContext dbContext;
+
+    public AccessTokenServiceTests(AuthWebApplicationFactory factory, DatabaseFixture dbFixture)
+    {
+        dbContext = dbFixture.DbContext;
+        httpClient = factory
+            .WithConnectionString(dbFixture.ConnectionString)
+            .CreateClient();
+
+        dbFixture.CleanUp();
+    }
+    
+    [Fact]
+    public async Task AccessService_Returns200_WithInvalidRequestErrorProfile_IfMessageIdNotProvided()
+    {
+        // Arrange
+        const string path = "/access/99/token?origin=http://whatever.example";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedProfile: "invalidRequest");
+    }
+    
+    [Fact]
+    public async Task AccessService_Returns200_WithInvalidRequestErrorProfile_IfOriginNotProvided()
+    {
+        // Arrange
+        const string path = "/access/99/token?messageId=12345";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedProfile: "invalidRequest");
+    }
+
+    [Fact]
+    public async Task AccessService_Returns200_WithMissingAspectErrorProfile_IfNoCookieProvided()
+    {
+        // Arrange
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedProfile: "missingAspect");
+    }
+    
+    [Fact]
+    public async Task AccessService_Returns200_WithInvalidAspectErrorProfile_IfCookieProvided_ButInvalidFormat()
+    {
+        // Arrange
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", "dlcs-auth2-99=unexpected-value;");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedProfile: "invalidAspect");
+    }
+
+    [Fact]
+    public async Task AccessService_Returns200_WithInvalidAspectErrorProfile_IfCookieProvidedWithId_ButIdNotInDatabase()
+    {
+        // Arrange
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", "dlcs-auth2-99=id=123456789;");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedProfile: "invalidAspect");
+    }
+    
+    [Fact]
+    public async Task AccessService_Returns200_WithInvalidAspectErrorProfile_IfCookieProvidedWithId_ButForDifferentCustomer()
+    {
+        // Arrange
+        const string cookieId =
+            nameof(AccessService_Returns200_WithInvalidAspectErrorProfile_IfCookieProvidedWithId_ButForDifferentCustomer);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId, customer: 10));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedProfile: "invalidAspect");
+    }
+    
+    [Fact]
+    public async Task AccessService_Returns200_WithExpiredAspectErrorProfile_IfCookieForExpiredSession()
+    {
+        // Arrange
+        const string cookieId =
+            nameof(AccessService_Returns200_WithExpiredAspectErrorProfile_IfCookieForExpiredSession);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId, expires: DateTime.UtcNow.AddMinutes(-10)));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedProfile: "expiredAspect");
+    }
+    
+    [Fact]
+    public async Task AccessService_Returns200_WithInvalidOriginErrorProfile_IfCookieForDifferentOrigin()
+    {
+        // Arrange
+        const string cookieId =
+            nameof(AccessService_Returns200_WithInvalidOriginErrorProfile_IfCookieForDifferentOrigin);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "/access/99/token?messageId=12345&origin=http://whatever.here";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedProfile: "invalidOrigin");
+    }
+
+    [Fact]
+    public async Task AccessService_Returns200_WithAccessToken_IfCookieValid()
+    {
+        // Arrange
+        const string cookieId = nameof(AccessService_Returns200_WithAccessToken_IfCookieValid);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await ValidateResponse(response, expectedAccessToken: "found-access-token");
+    }
+
+    [Fact]
+    public async Task AccessService_Returns200_ExtendsExpires_IfCookieValid_AndLastCheckedNull()
+    {
+        // Arrange
+        const string cookieId = nameof(AccessService_Returns200_ExtendsExpires_IfCookieValid_AndLastCheckedNull);
+        var sessionUser = await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        await httpClient.SendAsync(request);
+        
+        // Assert
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task AccessService_Returns200_ExtendsExpires_IfCookieValid_AndLastCheckedLongAgo()
+    {
+        // Arrange
+        const string cookieId = nameof(AccessService_Returns200_ExtendsExpires_IfCookieValid_AndLastCheckedLongAgo);
+        var sessionUser =
+            await dbContext.SessionUsers.AddAsync(
+                CreateSessionUser(cookieId, lastChecked: DateTime.UtcNow.AddHours(-1)));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        await httpClient.SendAsync(request);
+        
+        // Assert
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task AccessService_Returns200_DoesNotExtendsExpires_IfCookieValid_AndLastCheckedRecently()
+    {
+        // Arrange
+        var lastChecked = DateTime.UtcNow.AddSeconds(-100);
+        const string cookieId = nameof(AccessService_Returns200_DoesNotExtendsExpires_IfCookieValid_AndLastCheckedRecently);
+        var sessionUser =
+            await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId, lastChecked: lastChecked));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "/access/99/token?messageId=12345&origin=http://localhost";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        await httpClient.SendAsync(request);
+        
+        // Assert
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().Be(lastChecked);
+    }
+
+    private static async Task ValidateResponse(HttpResponseMessage response, string? expectedProfile = null,
+        string? expectedAccessToken = null)
+    {
+        var htmlParser = new HtmlParser();
+        var document = htmlParser.ParseDocument(await response.Content.ReadAsStreamAsync());
+        var el = document.QuerySelector("script") as IHtmlScriptElement;
+
+        if (!string.IsNullOrEmpty(expectedProfile))
+        {
+            el.Text.Should().Contain("\"type\": \"AuthAccessTokenError2\"",
+                "result is AuthAccessTokenError2");
+            el.Text.Should().Contain($"\"profile\": \"{expectedProfile}\"",
+                $"expected profile is '{expectedProfile}'");
+        }
+
+        if (!string.IsNullOrEmpty(expectedAccessToken))
+        {
+            el.Text.Should().Contain("\"type\": \"AuthAccessToken2\"",
+                "result is AuthAccessToken2");
+            el.Text.Should().Contain($"\"accessToken\": \"{expectedAccessToken}\"");
+            el.Text.Should().Contain("\"messageId\": \"12345\"");
+        }
+    }
+
+    private static SessionUser CreateSessionUser(string cookieId, int customer = 99, string origin = "http://localhost/",
+        DateTime? expires = null, DateTime? lastChecked = null)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            CookieId = cookieId,
+            AccessToken = "found-access-token",
+            Customer = customer,
+            Created = DateTime.UtcNow,
+            Roles = new List<string> { "foo" },
+            Expires = expires ?? DateTime.UtcNow.AddMinutes(5),
+            Origin = origin,
+            LastChecked = lastChecked
+        };
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Data/Entities/RoleProvisionToken.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Data/Entities/RoleProvisionToken.cs
@@ -24,6 +24,8 @@ public class RoleProvisionToken : IHaveCustomer
     public DateTime Created { get; set; }
     
     public int Customer { get; set; }
+
+    public string Origin { get; set; } = null!;
     
     /// <summary>
     /// For optimistic-concurrency, see https://www.npgsql.org/efcore/modeling/concurrency.html

--- a/src/IIIFAuth2/IIIFAuth2.API/Data/Entities/SessionUser.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Data/Entities/SessionUser.cs
@@ -8,10 +8,33 @@ public class SessionUser : IHaveCustomer
 {
     public Guid Id { get; set; }
     public int Customer { get; set; }
+    
+    /// <summary>
+    /// This value is set in the cookie (authorizing aspect)
+    /// </summary>
     public string CookieId { get; set; } = null!;
+    
+    /// <summary>
+    /// The origin that was sent when creating cookie
+    /// </summary>
+    public string Origin { get; set; } = null!;
+    
+    /// <summary>
+    /// Token returned from AccessTokenService, used in requests to ProbeService
+    /// </summary>
     public string AccessToken { get; set; } = null!;
+    
     public DateTime Expires { get; set; }
+    
     public DateTime Created { get; set; }
+    
+    /// <summary>
+    /// When expiry last checked
+    /// </summary>
     public DateTime? LastChecked { get; set; }
+    
+    /// <summary>
+    /// List of roles this session has access to
+    /// </summary>
     public List<string> Roles { get; set; } = new();
 }

--- a/src/IIIFAuth2/IIIFAuth2.API/Data/Migrations/20230728151317_SessionUser gains origin.Designer.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Data/Migrations/20230728151317_SessionUser gains origin.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IIIFAuth2.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IIIFAuth2.API.Data.Migrations
 {
     [DbContext(typeof(AuthServicesContext))]
-    partial class AuthServicesContextModelSnapshot : ModelSnapshot
+    [Migration("20230728151317_SessionUser gains origin")]
+    partial class SessionUsergainsorigin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/IIIFAuth2/IIIFAuth2.API/Data/Migrations/20230728151317_SessionUser gains origin.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Data/Migrations/20230728151317_SessionUser gains origin.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IIIFAuth2.API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SessionUsergainsorigin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "origin",
+                table: "session_users",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "origin",
+                table: "session_users");
+        }
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Data/Migrations/20230731132855_role_provision_token gains origin.Designer.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Data/Migrations/20230731132855_role_provision_token gains origin.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IIIFAuth2.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IIIFAuth2.API.Data.Migrations
 {
     [DbContext(typeof(AuthServicesContext))]
-    partial class AuthServicesContextModelSnapshot : ModelSnapshot
+    [Migration("20230731132855_role_provision_token gains origin")]
+    partial class role_provision_tokengainsorigin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/IIIFAuth2/IIIFAuth2.API/Data/Migrations/20230731132855_role_provision_token gains origin.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Data/Migrations/20230731132855_role_provision_token gains origin.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IIIFAuth2.API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class role_provision_tokengainsorigin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "origin",
+                table: "role_provision_tokens",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "origin",
+                table: "role_provision_tokens");
+        }
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessController.cs
@@ -12,7 +12,7 @@ namespace IIIFAuth2.API.Features.Access;
 [Route("[controller]")]
 public class AccessController : AuthBaseController
 {
-    public AccessController(IMediator mediator) : base(mediator)
+    public AccessController(IMediator mediator, ILogger<AccessController> logger) : base(mediator, logger)
     {
     }
 

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessTokenController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessTokenController.cs
@@ -1,0 +1,70 @@
+﻿using IIIF;
+using IIIF.Auth.V2;
+using IIIFAuth2.API.Features.Access.Requests;
+using IIIFAuth2.API.Infrastructure.Web;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IIIFAuth2.API.Features.Access;
+
+/// <summary>
+/// Controller for IIIF Authorization Flow 2.0 AccessTokenService
+/// </summary>
+/// <remarks>We don't use [ApiController] here as we always want to return a 200/HTML page with details of any errors</remarks>
+public class AccessTokenController : Controller
+{
+    private readonly IMediator mediator;
+    private readonly ILogger<AccessTokenController> logger;
+
+    public AccessTokenController(IMediator mediator, ILogger<AccessTokenController> logger)
+    {
+        this.mediator = mediator;
+        this.logger = logger;
+    }
+    
+    /// <summary>
+    /// Access Token Service, client exchanges authorising aspect for Token
+    /// as detailed in https://iiif.io/api/auth/2.0/#access-token-service
+    /// </summary>
+    [HttpGet]
+    [Route("access/{customerId}/token")]
+    public async Task<IActionResult> AccessTokenService(
+        [FromRoute] int customerId,
+        [FromQuery] string messageId,
+        [FromQuery] Uri? origin,
+        CancellationToken cancellationToken)
+    {
+        
+        ViewResult GenerateErrorResult(string profile, string heading, string note)
+        {
+            var accessTokenError = AuthServiceBuilder.CreateAuthAccessTokenError2(profile, messageId, heading, note);
+            return View("AccessTokenResponse", (accessTokenError as JsonLdBase, origin));
+        }
+        
+        try
+        {
+            if (string.IsNullOrEmpty(messageId))
+            {
+                return GenerateErrorResult(AuthAccessTokenError2.InvalidRequest, "Invalid Request",
+                    "Required messageId query parameter not provided");
+            }
+            
+            if (origin == null)
+            {
+                return GenerateErrorResult(AuthAccessTokenError2.InvalidRequest, "Invalid Request",
+                    "Required origin query parameter not provided or invalid");
+            }
+            
+            var initiate = new HandleAccessTokenRequest(customerId, origin, messageId);
+            var accessTokenResponse = await mediator.Send(initiate, cancellationToken);
+
+            return View("AccessTokenResponse", (accessTokenResponse, origin));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unexpected error handling AccessTokenRequest");
+            return GenerateErrorResult(AuthAccessTokenError2.Unavailable, "Unexpected error",
+                "Unexpected error processing request");
+        }
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessTokenController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessTokenController.cs
@@ -34,7 +34,6 @@ public class AccessTokenController : Controller
         [FromQuery] Uri? origin,
         CancellationToken cancellationToken)
     {
-        
         ViewResult GenerateErrorResult(string profile, string heading, string note)
         {
             var accessTokenError = AuthServiceBuilder.CreateAuthAccessTokenError2(profile, messageId, heading, note);
@@ -55,8 +54,8 @@ public class AccessTokenController : Controller
                     "Required origin query parameter not provided or invalid");
             }
             
-            var initiate = new HandleAccessTokenRequest(customerId, origin, messageId);
-            var accessTokenResponse = await mediator.Send(initiate, cancellationToken);
+            var accessTokenRequest = new HandleAccessTokenRequest(customerId, origin, messageId);
+            var accessTokenResponse = await mediator.Send(accessTokenRequest, cancellationToken);
 
             return View("AccessTokenResponse", (accessTokenResponse, origin));
         }

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AuthServiceBuilder.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AuthServiceBuilder.cs
@@ -1,0 +1,15 @@
+﻿using IIIF.Auth.V2;
+using IIIF.Presentation.V3.Strings;
+
+namespace IIIFAuth2.API.Features.Access;
+
+internal static class AuthServiceBuilder
+{
+    public static AuthAccessTokenError2 CreateAuthAccessTokenError2(string profile, string messageId, string heading,
+        string note)
+        => new(profile, new LanguageMap("en", note))
+        {
+            Heading = new LanguageMap("en", heading),
+            MessageId = messageId,
+        };
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/HandleAccessTokenRequest.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/HandleAccessTokenRequest.cs
@@ -55,7 +55,7 @@ public class HandleAccessTokenRequestHandler : IRequestHandler<HandleAccessToken
         {
             MessageId = messageId,
             AccessToken = sessionUser.AccessToken,
-            ExpiresIn = (int)(DateTime.UtcNow - sessionUser.Expires).TotalSeconds,
+            ExpiresIn = (int)(sessionUser.Expires - DateTime.UtcNow).TotalSeconds,
         };
 
     private static AuthAccessTokenError2 BuildAccessTokenError(GetSessionStatus getSessionStatus, string messageId)

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/HandleAccessTokenRequest.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/HandleAccessTokenRequest.cs
@@ -1,0 +1,86 @@
+﻿using IIIF;
+using IIIF.Auth.V2;
+using IIIF.Presentation.V3.Strings;
+using IIIFAuth2.API.Data.Entities;
+using IIIFAuth2.API.Infrastructure.Auth;
+using IIIFAuth2.API.Infrastructure.Auth.Models;
+using MediatR;
+
+namespace IIIFAuth2.API.Features.Access.Requests;
+
+/// <summary>
+/// Handle request for access token. Will return <see cref="AuthAccessToken2"/> or
+/// <see cref="AuthAccessTokenError2"/>
+/// </summary>
+public class HandleAccessTokenRequest : IRequest<JsonLdBase?>
+{
+    public int CustomerId { get; }
+    public string Origin { get; }
+    public string MessageId { get; }
+
+    public HandleAccessTokenRequest(int customerId, Uri origin, string messageId)
+    {
+        CustomerId = customerId;
+        Origin = origin.ToString();
+        MessageId = messageId;
+    }
+}
+
+public class HandleAccessTokenRequestHandler : IRequestHandler<HandleAccessTokenRequest, JsonLdBase?>
+{
+    private readonly SessionManagementService sessionManagementService;
+
+    public HandleAccessTokenRequestHandler(
+        SessionManagementService sessionManagementService)
+    {
+        this.sessionManagementService = sessionManagementService;
+    }
+    
+    public async Task<JsonLdBase?> Handle(HandleAccessTokenRequest request, CancellationToken cancellationToken)
+    {
+        var findSessionResponse =
+            await sessionManagementService.TryGetSessionUserForCookie(request.CustomerId, request.Origin,
+                cancellationToken);
+        
+        return BuildResponse(findSessionResponse, request.MessageId);
+    }
+
+    private static JsonLdBase BuildResponse(TryGetSessionResponse tryGetSessionResponse, string messageId)
+        => tryGetSessionResponse.Status == GetSessionStatus.Success && tryGetSessionResponse.SessionUser != null
+            ? BuildAccessTokenResponse(tryGetSessionResponse.SessionUser, messageId)
+            : BuildAccessTokenError(tryGetSessionResponse.Status, messageId);
+
+    private static AuthAccessToken2 BuildAccessTokenResponse(SessionUser sessionUser, string messageId)
+        => new()
+        {
+            MessageId = messageId,
+            AccessToken = sessionUser.AccessToken,
+            ExpiresIn = (int)(DateTime.UtcNow - sessionUser.Expires).TotalSeconds,
+        };
+
+    private static AuthAccessTokenError2 BuildAccessTokenError(GetSessionStatus getSessionStatus, string messageId)
+    {
+        var (profile, heading, note) = GetErrorProps(getSessionStatus);
+        return AuthServiceBuilder.CreateAuthAccessTokenError2(profile, messageId, heading, note);
+    }
+
+    private static (string Profile, string Heading, string Note) GetErrorProps(GetSessionStatus status)
+        => status switch
+        {
+            GetSessionStatus.MissingSession => (AuthAccessTokenError2.InvalidAspect, "Invalid cookie",
+                "Authorising cookie invalid"),
+            GetSessionStatus.DifferentOrigin => (AuthAccessTokenError2.InvalidOrigin, "Origin invalid",
+                "Requested origin differs from access service request"),
+            GetSessionStatus.MissingCookie => (AuthAccessTokenError2.MissingAspect, "Missing cookie",
+                "Authorising cookie not found"),
+            GetSessionStatus.InvalidCookie => (AuthAccessTokenError2.InvalidAspect, "Invalid cookie",
+                "Authorising cookie invalid"),
+            GetSessionStatus.ExpiredSession => (AuthAccessTokenError2.ExpiredAspect, "Expired session",
+                "Authorising cookie found but expired"),
+            GetSessionStatus.UnknownError => (AuthAccessTokenError2.Unavailable, "Request cannot be fulfilled",
+                "Unexpected error fulfilling request"),
+            GetSessionStatus.Success => (AuthAccessTokenError2.Unavailable, "Request cannot be fulfilled",
+                "Unexpected error fulfilling request"),
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+        };
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/InitiateRoleProvisionRequest.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/InitiateRoleProvisionRequest.cs
@@ -42,7 +42,7 @@ public class InitiateRoleProvisionRequestHandler : IRequestHandler<InitiateRoleP
     {
         var originMatchesHost = OriginMatchesHost(request);
         var handled = await roleProviderService.HandleRequest(request.CustomerId, request.AccessServiceName,
-            originMatchesHost, cancellationToken);
+            originMatchesHost, request.Origin, cancellationToken);
         return handled;
     }
 

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/AccessTokenResponse.cshtml
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/AccessTokenResponse.cshtml
@@ -1,0 +1,17 @@
+@using IIIF.Serialisation
+@model (IIIF.JsonLdBase TokenResponse, Uri Origin)
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+  <title>Access Token Response</title>
+</head>
+<body>
+<script>
+    window.parent.postMessage(
+      @Html.Raw(Model.TokenResponse.AsJson()),
+      @Model.Origin
+    );
+</script>
+</body>
+</html>

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Presentation/ServicesController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Presentation/ServicesController.cs
@@ -12,7 +12,7 @@ namespace IIIFAuth2.API.Features.Presentation;
 [Route("[controller]")]
 public class ServicesController : AuthBaseController
 {
-    public ServicesController(IMediator mediator) : base(mediator)
+    public ServicesController(IMediator mediator, ILogger<ServicesController> logger) : base(mediator, logger)
     {
     }
     

--- a/src/IIIFAuth2/IIIFAuth2.API/IIIFAuth2.API.csproj
+++ b/src/IIIFAuth2/IIIFAuth2.API/IIIFAuth2.API.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
-      <PackageReference Include="iiif-net" Version="0.2.0" />
+      <PackageReference Include="iiif-net" Version="0.2.1" />
       <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.9">

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AuthCookieManager.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AuthCookieManager.cs
@@ -37,6 +37,24 @@ public class AuthCookieManager
         => $"{CookiePrefix}{cookieId}";
     
     /// <summary>
+    /// Get the CookieId from cookieValue
+    /// </summary>
+    public string? GetCookieIdFromValue(string cookieValue)
+        => cookieValue.StartsWith(CookiePrefix) ? cookieValue[3..] : null;
+    
+    /// <summary>
+    /// Get Cookie for specified customer
+    /// </summary>
+    public string? GetCookieValueForCustomer(int customer)
+    {
+        var httpContext = httpContextAccessor.HttpContext.ThrowIfNull(nameof(httpContextAccessor.HttpContext));
+        var cookieKey = GetAuthCookieKey(authSettings.CookieNameFormat, customer);
+        return httpContext.Request.Cookies.TryGetValue(cookieKey, out var cookieValue)
+            ? cookieValue
+            : null;
+    }
+    
+    /// <summary>
     /// Add cookie to current Response object, using details from specified <see cref="SessionUser"/>
     /// </summary>
     public void IssueCookie(SessionUser sessionUser)

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/TryGetSessionResponse.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/TryGetSessionResponse.cs
@@ -1,0 +1,46 @@
+﻿using IIIFAuth2.API.Data.Entities;
+
+namespace IIIFAuth2.API.Infrastructure.Auth.Models;
+
+/// <summary>
+/// Represents the result of call to exchange cookie or access-token for a session user
+/// </summary>
+public record TryGetSessionResponse(GetSessionStatus Status, SessionUser? SessionUser = null);
+
+public enum GetSessionStatus
+{
+    /// <summary>
+    /// Requested session not found
+    /// </summary>
+    MissingSession,
+    
+    /// <summary>
+    /// Origin provided differs from that in DB
+    /// </summary>
+    DifferentOrigin,
+    
+    /// <summary>
+    /// Cookie not found
+    /// </summary>
+    MissingCookie,
+    
+    /// <summary>
+    /// Cookie found but invalid
+    /// </summary>
+    InvalidCookie,
+    
+    /// <summary>
+    /// User session found but it has expired
+    /// </summary>
+    ExpiredSession,
+    
+    /// <summary>
+    /// Any other error
+    /// </summary>
+    UnknownError,
+    
+    /// <summary>
+    /// Success
+    /// </summary>
+    Success
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/ClickthroughRoleProviderHandler.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/ClickthroughRoleProviderHandler.cs
@@ -30,6 +30,7 @@ public class ClickthroughRoleProviderHandler : IRoleProviderHandler
     }
 
     public async Task<HandleRoleProvisionResponse> HandleRequest(int customerId,
+        string requestOrigin,
         AccessService accessService,
         IProviderConfiguration providerConfiguration,
         bool hostIsOrigin,
@@ -46,12 +47,12 @@ public class ClickthroughRoleProviderHandler : IRoleProviderHandler
 
         if (hostIsOrigin)
         {
-            await sessionManagementService.CreateSessionForRoles(customerId, roles, cancellationToken);
+            await sessionManagementService.CreateSessionForRoles(customerId, roles, requestOrigin, cancellationToken);
             return HandleRoleProvisionResponse.Handled();
         }
 
         // We need to capture a significant gesture on this domain before we can issue a cookie
-        var gestureModel = await GetSignificantGestureModel(customerId, roles, configuration, cancellationToken);
+        var gestureModel = await GetSignificantGestureModel(customerId, roles, requestOrigin, configuration, cancellationToken);
         return HandleRoleProvisionResponse.SignificantGesture(gestureModel);
     }
 
@@ -72,10 +73,10 @@ public class ClickthroughRoleProviderHandler : IRoleProviderHandler
     }
 
     private async Task<SignificantGestureModel> GetSignificantGestureModel(int customerId, IReadOnlyCollection<string> roles,
-        ClickthroughConfiguration configuration, CancellationToken cancellationToken)
+        string origin, ClickthroughConfiguration configuration, CancellationToken cancellationToken)
     {
         var expiringToken =
-            await sessionManagementService.CreateRoleProvisionToken(customerId, roles, cancellationToken);
+            await sessionManagementService.CreateRoleProvisionToken(customerId, roles, origin, cancellationToken);
         var gestureModel = new SignificantGestureModel(
             configuration.GestureTitle ?? apiSettings.DefaultSignificantGestureTitle,
             configuration.GestureMessage ?? apiSettings.DefaultSignificantGestureMessage,

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/IRoleProviderHandler.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/IRoleProviderHandler.cs
@@ -18,6 +18,6 @@ public interface IRoleProviderHandler
     /// create a session + issue a cookie (if authorizing aspect present) or request the user carry out a significant
     /// gesture in order that a cookie may be issues for that domain
     /// </summary>
-    Task<HandleRoleProvisionResponse> HandleRequest(int customerId, AccessService accessService,
+    Task<HandleRoleProvisionResponse> HandleRequest(int customerId, string requestOrigin, AccessService accessService,
         IProviderConfiguration providerConfiguration, bool hostIsOrigin, CancellationToken cancellationToken = default);
 }

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/RoleProviderService.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/RoleProviderService.cs
@@ -22,7 +22,8 @@ public class RoleProviderService
         this.logger = logger;
     }
 
-    public async Task<HandleRoleProvisionResponse?> HandleRequest(int customerId, string accessServiceName, bool hostIsOrigin, CancellationToken cancellationToken = default)
+    public async Task<HandleRoleProvisionResponse?> HandleRequest(int customerId, string accessServiceName,
+        bool hostIsOrigin, Uri requestOrigin, CancellationToken cancellationToken = default)
     {
         var accessService = await GetAccessServices(customerId, accessServiceName);
         if (accessService == null) return null;
@@ -40,8 +41,8 @@ public class RoleProviderService
         var providerConfiguration = roleProvider.Configuration.GetDefaultConfiguration();
         var handler = handlerResolver(providerConfiguration.Config);
 
-        var result = await handler.HandleRequest(customerId, accessService, providerConfiguration, hostIsOrigin,
-            cancellationToken);
+        var result = await handler.HandleRequest(customerId, requestOrigin.ToString(), accessService,
+            providerConfiguration, hostIsOrigin, cancellationToken);
         return result;
     }
 

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Web/AuthBaseController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Web/AuthBaseController.cs
@@ -8,11 +8,13 @@ namespace IIIFAuth2.API.Infrastructure.Web;
 public abstract class AuthBaseController : Controller
 {
     protected readonly IMediator Mediator;
+    protected readonly ILogger Logger;
 
     /// <inheritdoc />
-    protected AuthBaseController(IMediator mediator)
+    protected AuthBaseController(IMediator mediator, ILogger logger)
     {
         Mediator = mediator;
+        Logger = logger;
     }
     
     protected async Task<IActionResult> HandleRequest(
@@ -49,10 +51,12 @@ public abstract class AuthBaseController : Controller
         }
         catch (FormatException fmtEx)
         {
+            Logger.LogDebug(fmtEx, "Format exception processing request");
             return Problem(detail: fmtEx.Message, statusCode: 400, title: errorTitle ?? "Bad Request");
         }
         catch (Exception ex)
         {
+            Logger.LogDebug(ex, "Unexpected exception processing request");
             return Problem(detail: ex.Message, statusCode: 500, title: errorTitle ?? "Unexpected error");
         }
     }

--- a/src/IIIFAuth2/IIIFAuth2.API/Settings/ApiSettings.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Settings/ApiSettings.cs
@@ -30,9 +30,15 @@ public class AuthSettings
     public string CookieNameFormat { get; set; } = "dlcs-auth2-{0}";
 
     /// <summary>
-    /// Default TTL for sessions + cookies
+    /// Default TTL for sessions + cookies in secs
     /// </summary>
     public int SessionTtl { get; set; } = 600;
+
+    /// <summary>
+    /// UserSession expiry not refreshed if LastChecked within this number of secs
+    /// </summary>
+    /// <remarks>This avoids constant churn in db</remarks>
+    public int RefreshThreshold { get; set; } = 120;
 
     /// <summary>
     /// A list of domains to set on auth cookie.


### PR DESCRIPTION
Implement Access Token Service (https://iiif.io/api/auth/2.0/#access-token-service)

Implemented as `GET /access/{customer}/token`. The viewer uses the access-token-service to exchange the cookie (the 'authorizing aspect') received from access-service for an access-token which can be provided to the probe-service.

Implemented as a separate controller, we _always_ want to return a 200 status code an an HTML page containing either the access-token or details of any error that occurred.

The bulk of the logic is in `SessionManagementService.TryGetSessionUserForCookie`. This will return a `TryGetSessionResponse` object containing the `SessionUser`, if found, or an `GetSessionStatus` enum value detailing what went wrong. If the `SessionUser` is found it may have it's `expires` value extended in database.

Part of validation logic is checking value of `?origin` provided to access-token-service matches that passed to access-service. Updated DB to save this value to do check.

Resolves #1 