### PR TITLE
Add internal/downstream endpoints (probe and verifyaccess)

### DIFF
--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/AuthAspectManagerTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/AuthAspectManagerTests.cs
@@ -7,12 +7,12 @@ using Microsoft.Extensions.Options;
 
 namespace IIIFAuth2.API.Tests.Infrastructure.Auth;
 
-public class AuthCookieManagerTests
+public class AuthAspectManagerTests
 {
     private readonly IHttpContextAccessor contextAccessor;
     private readonly HttpRequest request;
 
-    public AuthCookieManagerTests()
+    public AuthAspectManagerTests()
     {
         var context = new DefaultHttpContext();
         request = context.Request;
@@ -205,7 +205,7 @@ public class AuthCookieManagerTests
         actual.Should().BeNull();
     }
     
-    private AuthCookieManager GetSut(bool useCurrentDomainForCookie = true, params string[] additionalDomains)
+    private AuthAspectManager GetSut(bool useCurrentDomainForCookie = true, params string[] additionalDomains)
     {
         var options = Options.Create(new AuthSettings
         {
@@ -213,6 +213,6 @@ public class AuthCookieManagerTests
             CookieNameFormat = "auth-token-{0}",
             UseCurrentDomainForCookie = useCurrentDomainForCookie
         });
-        return new AuthCookieManager(contextAccessor, options);
+        return new AuthAspectManager(contextAccessor, options);
     }
 }

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/AuthAspectManagerTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/AuthAspectManagerTests.cs
@@ -204,6 +204,53 @@ public class AuthAspectManagerTests
         // Assert
         actual.Should().BeNull();
     }
+
+    [Fact]
+    public void GetAccessToken_Null_IfNoAuthHeader()
+    {
+        // Arrange
+        var sut = GetSut();
+        
+        // Act
+        var bearerToken = sut.GetAccessToken();
+        
+        // Assert
+        bearerToken.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("basic Zm9vOmJhcg==")]
+    [InlineData("digest username=\"Test\" algorithm=MD5")]
+    [InlineData("negotiate foo")]
+    [InlineData("random bar")]
+    public void GetAccessToken_Null_IfAuthHeaderProvided_ButNotBearer(string authHeaderValue)
+    {
+        // Arrange
+        var sut = GetSut();
+        request.Headers.Append("Authorization", authHeaderValue);
+        
+        // Act
+        var bearerToken = sut.GetAccessToken();
+        
+        // Assert
+        bearerToken.Should().BeNull();
+    }
+    
+    [Theory]
+    [InlineData("bearer foo-bar")]
+    [InlineData("Bearer foo-bar")]
+    public void GetAccessToken_ReturnsValue_IfProvided(string authHeaderValue)
+    {
+        // Arrange
+        var sut = GetSut();
+        request.Headers.Append("Authorization", authHeaderValue);
+        
+        // Act
+        var bearerToken = sut.GetAccessToken();
+        
+        // Assert
+        bearerToken.Should().Be("foo-bar");
+    }
     
     private AuthAspectManager GetSut(bool useCurrentDomainForCookie = true, params string[] additionalDomains)
     {

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/Models/TryGetSessionResponseXTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/Models/TryGetSessionResponseXTests.cs
@@ -1,0 +1,43 @@
+﻿using IIIFAuth2.API.Data.Entities;
+using IIIFAuth2.API.Infrastructure.Auth.Models;
+
+namespace IIIFAuth2.API.Tests.Infrastructure.Auth.Models;
+
+public class TryGetSessionResponseXTests
+{
+    [Theory]
+    [InlineData(GetSessionStatus.MissingSession)]
+    [InlineData(GetSessionStatus.DifferentOrigin)]
+    [InlineData(GetSessionStatus.MissingCredentials)]
+    [InlineData(GetSessionStatus.InvalidCookie)]
+    [InlineData(GetSessionStatus.ExpiredSession)]
+    [InlineData(GetSessionStatus.UnknownError)]
+    public void IsSuccessful_False_IfNotSuccess_AndHasSessionUser(GetSessionStatus status)
+    {
+        // Arrange
+        var tryGetSession = new TryGetSessionResponse(status, new SessionUser());
+        
+        // Assert
+        tryGetSession.IsSuccessWithSession().Should().BeFalse();
+    }
+    
+    [Fact]
+    public void IsSuccessful_False_IfSuccessStatus_NoSessionUser()
+    {
+        // Arrange
+        var tryGetSession = new TryGetSessionResponse(GetSessionStatus.Success);
+        
+        // Assert
+        tryGetSession.IsSuccessWithSession().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSuccessful_True_IfSuccessStatus_AndHasSessionUser()
+    {
+        // Arrange
+        var tryGetSession = new TryGetSessionResponse(GetSessionStatus.Success, new SessionUser());
+        
+        // Assert
+        tryGetSession.IsSuccessWithSession().Should().BeTrue();
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/Models/TryGetSessionResponseXTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/Models/TryGetSessionResponseXTests.cs
@@ -40,4 +40,80 @@ public class TryGetSessionResponseXTests
         // Assert
         tryGetSession.IsSuccessWithSession().Should().BeTrue();
     }
+
+    [Theory]
+    [InlineData(GetSessionStatus.MissingSession)]
+    [InlineData(GetSessionStatus.DifferentOrigin)]
+    [InlineData(GetSessionStatus.MissingCredentials)]
+    [InlineData(GetSessionStatus.InvalidCookie)]
+    [InlineData(GetSessionStatus.ExpiredSession)]
+    [InlineData(GetSessionStatus.UnknownError)]
+    public void CanUserAccessAtLeastOneRole_False_IfNotSuccess(GetSessionStatus status)
+    {
+        // Arrange
+        var roles = new List<string> { "foo" };
+        var tryGetSession = new TryGetSessionResponse(status, new SessionUser { Roles = roles });
+        
+        // Assert
+        tryGetSession.CanUserAccessAtLeastOneRole(roles).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void CanUserAccessAtLeastOneRole_False_IfNoSessionUser()
+    {
+        // Arrange
+        var roles = new List<string> { "foo" };
+        var tryGetSession = new TryGetSessionResponse(GetSessionStatus.Success);
+        
+        // Assert
+        tryGetSession.CanUserAccessAtLeastOneRole(roles).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void CanUserAccessAtLeastOneRole_False_NullRoles()
+    {
+        // Arrange
+        var roles = new List<string> { "foo" };
+        var tryGetSession = new TryGetSessionResponse(GetSessionStatus.Success, new SessionUser());
+        
+        // Assert
+        tryGetSession.CanUserAccessAtLeastOneRole(roles).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void CanUserAccessAtLeastOneRole_False_EmptyRoles()
+    {
+        // Arrange
+        var roles = new List<string> { "foo" };
+        var tryGetSession =
+            new TryGetSessionResponse(GetSessionStatus.Success, new SessionUser { Roles = new List<string>(0) });
+        
+        // Assert
+        tryGetSession.CanUserAccessAtLeastOneRole(roles).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void CanUserAccessAtLeastOneRole_False_NoMatches()
+    {
+        // Arrange
+        var roles = new List<string> { "foo" };
+        var tryGetSession =
+            new TryGetSessionResponse(GetSessionStatus.Success, new SessionUser { Roles = new List<string> { "bar" } });
+        
+        // Assert
+        tryGetSession.CanUserAccessAtLeastOneRole(roles).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void CanUserAccessAtLeastOneRole_True_IfMatch()
+    {
+        // Arrange
+        var roles = new List<string> { "foo", "bar" };
+        var tryGetSession =
+            new TryGetSessionResponse(GetSessionStatus.Success,
+                new SessionUser { Roles = new List<string> { "baz", "bar" } });
+        
+        // Assert
+        tryGetSession.CanUserAccessAtLeastOneRole(roles).Should().BeTrue();
+    }
 }

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/ProbeServiceTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/ProbeServiceTests.cs
@@ -1,0 +1,318 @@
+﻿using System.Net;
+using IIIF.Auth.V2;
+using IIIF.Serialisation;
+using IIIFAuth2.API.Data;
+using IIIFAuth2.API.Data.Entities;
+using IIIFAuth2.API.Tests.TestingInfrastructure;
+
+namespace IIIFAuth2.API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(DatabaseCollection.CollectionName)]
+public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
+{
+    private readonly HttpClient httpClient;
+    private readonly AuthServicesContext dbContext;
+
+    public ProbeServiceTests(AuthWebApplicationFactory factory, DatabaseFixture dbFixture)
+    {
+        dbContext = dbFixture.DbContext;
+        httpClient = factory
+            .WithConnectionString(dbFixture.ConnectionString)
+            .CreateClient();
+
+        dbFixture.CleanUp();
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns400StatusProperty_IfRolesMissing()
+    {
+        // Arrange
+        const string path = "probe/99/2/assetname";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(400);
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns400StatusProperty_IfAssetIdInvalid()
+    {
+        // Arrange
+        const string path = "probe/12345?roles=hello";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task GetProbeService_Returns401StatusProperty_IfNoBearerToken()
+    {
+        // Arrange
+        const string path = "probe/99/2/foo?roles=clickthrough";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Missing credentials");
+        authProbeResult.Note["en"].Should().ContainSingle(s => s == "Authorising credentials not found");
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns401StatusProperty_IfAuthHeaderProvided_NotBearerToken()
+    {
+        // Arrange
+        const string path = "probe/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", "Basic amV3ZWxzOmJpbm9jdWxhcnM=");
+            
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Missing credentials");
+        authProbeResult.Note["en"].Should().ContainSingle(s => s == "Authorising credentials not found");
+    }
+
+    [Fact]
+    public async Task GetProbeService_Returns401StatusProperty_IfBearerTokenProvided_ButNotInDatabase()
+    {
+        // Arrange
+        const string path = "probe/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", "Bearer foo-bar");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Invalid credentials");
+        authProbeResult.Note["en"].Should().ContainSingle(s => s == "Authorising credentials invalid");
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns401StatusProperty_IfBearerTokenProvided_ButForDifferentCustomer()
+    {
+        // Arrange
+        const string accessToken =
+            nameof(GetProbeService_Returns401StatusProperty_IfBearerTokenProvided_ButForDifferentCustomer);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(accessToken, customer: 10));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "probe/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Invalid credentials");
+        authProbeResult.Note["en"].Should().ContainSingle(s => s == "Authorising credentials invalid");
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns401StatusProperty_IfBearerTokenProvidedForExpiredSession()
+    {
+        // Arrange
+        const string accessToken =
+            nameof(GetProbeService_Returns401StatusProperty_IfBearerTokenProvidedForExpiredSession);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(accessToken, expires: DateTime.UtcNow.AddMinutes(-10)));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "probe/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Expired session");
+        authProbeResult.Note["en"].Should().ContainSingle(s => s == "Session has expired");
+    }
+
+    [Fact]
+    public async Task GetProbeService_Returns403StatusProperty_IfBearerTokenValid_ButMissingRequiredRoles()
+    {
+        // Arrange
+        const string accessToken =
+            nameof(GetProbeService_Returns403StatusProperty_IfBearerTokenValid_ButMissingRequiredRoles);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(accessToken));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "probe/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(403);
+        authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Forbidden");
+        authProbeResult.Note["en"].Should().ContainSingle(s => s == "Session does not have required roles");
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns200StatusProperty_IfBearerTokenValid_AndHasRequiredRoles()
+    {
+        // Arrange
+        const string accessToken =
+            nameof(GetProbeService_Returns200StatusProperty_IfBearerTokenValid_AndHasRequiredRoles);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(accessToken));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "probe/99/2/foo?roles=clickthrough,foo";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        authProbeResult.Status.Should().Be(200);
+        authProbeResult.Heading.Should().BeNull();
+        authProbeResult.Note.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns200StatusProperty_ExtendsExpires_IfBearerTokenValid_AndLastCheckedNull()
+    {
+        // Arrange
+        const string accessToken =
+            nameof(GetProbeService_Returns200StatusProperty_ExtendsExpires_IfBearerTokenValid_AndLastCheckedNull);
+        var sessionUser = await dbContext.SessionUsers.AddAsync(CreateSessionUser(accessToken));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "probe/99/2/foo?roles=clickthrough,foo";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(3));
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns200StatusProperty_ExtendsExpires_IfBearerTokenValid_AndLastCheckedLongAgo()
+    {
+        // Arrange
+        const string accessToken =
+            nameof(GetProbeService_Returns200StatusProperty_ExtendsExpires_IfBearerTokenValid_AndLastCheckedLongAgo);
+        var sessionUser =
+            await dbContext.SessionUsers.AddAsync(CreateSessionUser(accessToken,
+                lastChecked: DateTime.UtcNow.AddHours(-1)));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "probe/99/2/foo?roles=clickthrough,foo";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(3));
+    }
+    
+    [Fact]
+    public async Task GetProbeService_Returns200_DoesNotExtendsExpires_IfBearerTokenValid_AndLastCheckedRecently()
+    {
+        // Arrange
+        var lastChecked = DateTime.UtcNow.AddSeconds(-100);
+        const string accessToken =
+            nameof(GetProbeService_Returns200_DoesNotExtendsExpires_IfBearerTokenValid_AndLastCheckedRecently);
+        var sessionUser =
+            await dbContext.SessionUsers.AddAsync(CreateSessionUser(accessToken, lastChecked: lastChecked));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "probe/99/2/foo?roles=clickthrough,foo";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(lastChecked, TimeSpan.FromMilliseconds(100));
+    }
+    
+    [Fact]
+    public async Task GetProbeService_ExtendsCookie_IfBearerTokenValid()
+    {
+        // Arrange
+        const string accessToken = nameof(GetProbeService_ExtendsCookie_IfBearerTokenValid);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(accessToken));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "probe/99/2/foo?roles=clickthrough,foo";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        response.Headers.Should().ContainKey("Set-Cookie");
+        var cookie = response.Headers.SingleOrDefault(header => header.Key == "Set-Cookie").Value.First();
+        cookie.Should()
+            .StartWith("dlcs-auth2-99")
+            .And.Contain("samesite=none")
+            .And.Contain("secure;");
+    }
+
+    private static SessionUser CreateSessionUser(string accessToken, int customer = 99, DateTime? expires = null,
+        DateTime? lastChecked = null)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            CookieId = "cookie-id",
+            AccessToken = accessToken,
+            Customer = customer,
+            Created = DateTime.UtcNow,
+            Roles = new List<string> { "foo" },
+            Expires = expires ?? DateTime.UtcNow.AddMinutes(5),
+            Origin = "http://irrelevant-for-this/",
+            LastChecked = lastChecked
+        };
+}

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/ProbeServiceTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/ProbeServiceTests.cs
@@ -36,7 +36,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(400);
+        authProbeResult.Status.Should().Be(400, "BadRequest (400) expected");
     }
     
     [Fact]
@@ -51,7 +51,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(400);
+        authProbeResult.Status.Should().Be(400, "BadRequest (400) expected");
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Status.Should().Be(401, "Unauthorized (401) expected");
         authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Missing credentials");
         authProbeResult.Note["en"].Should().ContainSingle(s => s == "Authorising credentials not found");
     }
@@ -85,7 +85,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Status.Should().Be(401, "Unauthorized (401) expected");
         authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Missing credentials");
         authProbeResult.Note["en"].Should().ContainSingle(s => s == "Authorising credentials not found");
     }
@@ -104,7 +104,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Status.Should().Be(401, "Unauthorized (401) expected");
         authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Invalid credentials");
         authProbeResult.Note["en"].Should().ContainSingle(s => s == "Authorising credentials invalid");
     }
@@ -128,7 +128,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Status.Should().Be(401, "Unauthorized (401) expected");
         authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Invalid credentials");
         authProbeResult.Note["en"].Should().ContainSingle(s => s == "Authorising credentials invalid");
     }
@@ -152,7 +152,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(401);
+        authProbeResult.Status.Should().Be(401, "Unauthorized (401) expected");
         authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Expired session");
         authProbeResult.Note["en"].Should().ContainSingle(s => s == "Session has expired");
     }
@@ -176,7 +176,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(403);
+        authProbeResult.Status.Should().Be(403, "Forbidden (403) expected");
         authProbeResult.Heading["en"].Should().ContainSingle(s => s == "Forbidden");
         authProbeResult.Note["en"].Should().ContainSingle(s => s == "Session does not have required roles");
     }
@@ -200,7 +200,7 @@ public class ProbeServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var authProbeResult = (await response.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
-        authProbeResult.Status.Should().Be(200);
+        authProbeResult.Status.Should().Be(200, "OK (200) expected");
         authProbeResult.Heading.Should().BeNull();
         authProbeResult.Note.Should().BeNull();
     }

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/VerifyAccessTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/VerifyAccessTests.cs
@@ -1,0 +1,284 @@
+﻿using System.Net;
+using IIIFAuth2.API.Data;
+using IIIFAuth2.API.Data.Entities;
+using IIIFAuth2.API.Tests.TestingInfrastructure;
+
+namespace IIIFAuth2.API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(DatabaseCollection.CollectionName)]
+public class VerifyAccessTests : IClassFixture<AuthWebApplicationFactory>
+{
+    private readonly HttpClient httpClient;
+    private readonly AuthServicesContext dbContext;
+
+    public VerifyAccessTests(AuthWebApplicationFactory factory, DatabaseFixture dbFixture)
+    {
+        dbContext = dbFixture.DbContext;
+        httpClient = factory
+            .WithConnectionString(dbFixture.ConnectionString)
+            .CreateClient();
+
+        dbFixture.CleanUp();
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns400_IfRolesMissing()
+    {
+        // Arrange
+        const string path = "verifyaccess/99/2/assetname";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns400_IfAssetIdInvalid()
+    {
+        // Arrange
+        const string path = "verifyaccess/12345?roles=hello";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns401_IfNoCookie()
+    {
+        // Arrange
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns401_IfCookieProvided_InvalidFormat()
+    {
+        // Arrange
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", "dlcs-auth2-99=unexpected-value;");
+            
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns401_IfCookieProvidedWithId_ButIdNotInDatabase()
+    {
+        // Arrange
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", "dlcs-auth2-99=id=123456789;");
+            
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns401_IfCookieProvidedWithId_ButForDifferentCustomer()
+    {
+        // Arrange
+        // Arrange
+        const string cookieId =
+            nameof(VerifyAccess_Returns401_IfCookieProvidedWithId_ButForDifferentCustomer);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId, customer: 10));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+            
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns403_IfCookieProvidedWithId_ButSessionDoesNotHaveRoles()
+    {
+        // Arrange
+        // Arrange
+        const string cookieId = nameof(VerifyAccess_Returns403_IfCookieProvidedWithId_ButSessionDoesNotHaveRoles);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "verifyaccess/99/2/foo?roles=foo";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+            
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns401_IfCookieForExpiredSession()
+    {
+        // Arrange
+        // Arrange
+        const string cookieId = nameof(VerifyAccess_Returns401_IfCookieForExpiredSession);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId, expires: DateTime.UtcNow.AddMinutes(-10)));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+            
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_Returns200_IfCookieValid()
+    {
+        // Arrange
+        // Arrange
+        const string cookieId = nameof(VerifyAccess_Returns200_IfCookieValid);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+            
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+    
+    [Fact]
+    public async Task VerifyAccess_ExtendsCookie_IfCookieValid()
+    {
+        // Arrange
+        // Arrange
+        const string cookieId = nameof(VerifyAccess_ExtendsCookie_IfCookieValid);
+        await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+            
+        // Act
+        var response = await httpClient.SendAsync(request);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        response.Headers.Should().ContainKey("Set-Cookie");
+        var cookie = response.Headers.SingleOrDefault(header => header.Key == "Set-Cookie").Value.First();
+        cookie.Should()
+            .StartWith("dlcs-auth2-99")
+            .And.Contain("samesite=none")
+            .And.Contain("secure;");
+    }
+
+    [Fact]
+    public async Task VerifyAccess_Returns200_ExtendsExpires_IfCookieValid_AndLastCheckedNull()
+    {
+        // Arrange
+        const string cookieId = nameof(VerifyAccess_Returns200_ExtendsExpires_IfCookieValid_AndLastCheckedNull);
+        var sessionUser = await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task VerifyAccess_Returns200_ExtendsExpires_IfCookieValid_AndLastCheckedLongAgo()
+    {
+        // Arrange
+        const string cookieId = nameof(VerifyAccess_Returns200_ExtendsExpires_IfCookieValid_AndLastCheckedLongAgo);
+        var sessionUser =
+            await dbContext.SessionUsers.AddAsync(
+                CreateSessionUser(cookieId, lastChecked: DateTime.UtcNow.AddHours(-1)));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task VerifyAccess_Returns200_DoesNotExtendsExpires_IfCookieValid_AndLastCheckedRecently()
+    {
+        // Arrange
+        var lastChecked = DateTime.UtcNow.AddSeconds(-100);
+        const string cookieId = nameof(VerifyAccess_Returns200_DoesNotExtendsExpires_IfCookieValid_AndLastCheckedRecently);
+        var sessionUser =
+            await dbContext.SessionUsers.AddAsync(CreateSessionUser(cookieId, lastChecked: lastChecked));
+        await dbContext.SaveChangesAsync();
+        
+        const string path = "verifyaccess/99/2/foo?roles=clickthrough";
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-auth2-99=id={cookieId};");
+        
+        // Act
+        var response = await httpClient.SendAsync(request);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        await dbContext.Entry(sessionUser.Entity).ReloadAsync();
+        sessionUser.Entity.LastChecked.Should().BeCloseTo(lastChecked, TimeSpan.FromMilliseconds(100));
+    }
+
+    private static SessionUser CreateSessionUser(string cookieId, int customer = 99, string origin = "http://localhost/",
+        DateTime? expires = null, DateTime? lastChecked = null)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            CookieId = cookieId,
+            AccessToken = "found-access-token",
+            Customer = customer,
+            Created = DateTime.UtcNow,
+            Roles = new List<string> { "clickthrough" },
+            Expires = expires ?? DateTime.UtcNow.AddMinutes(5),
+            Origin = origin,
+            LastChecked = lastChecked
+        };
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Data/CacheKeys.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Data/CacheKeys.cs
@@ -3,7 +3,9 @@
 public static class CacheKeys
 {
     public static string Customer(int customerId) => $"c:{customerId}";
-
+    
+    public static string AuthAspect(string aspectValue, string? origin = null) => $"aa:{aspectValue}:{origin}";
+    
     public static readonly string AccessService = "accessServices";
 
     public static readonly string Roles = "roles";

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessTokenController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessTokenController.cs
@@ -1,7 +1,6 @@
 ﻿using IIIF;
 using IIIF.Auth.V2;
 using IIIFAuth2.API.Features.Access.Requests;
-using IIIFAuth2.API.Infrastructure.Web;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/HandleAccessTokenRequest.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/HandleAccessTokenRequest.cs
@@ -1,6 +1,5 @@
 ﻿using IIIF;
 using IIIF.Auth.V2;
-using IIIF.Presentation.V3.Strings;
 using IIIFAuth2.API.Data.Entities;
 using IIIFAuth2.API.Infrastructure.Auth;
 using IIIFAuth2.API.Infrastructure.Auth.Models;
@@ -46,8 +45,8 @@ public class HandleAccessTokenRequestHandler : IRequestHandler<HandleAccessToken
     }
 
     private static JsonLdBase BuildResponse(TryGetSessionResponse tryGetSessionResponse, string messageId)
-        => tryGetSessionResponse.Status == GetSessionStatus.Success && tryGetSessionResponse.SessionUser != null
-            ? BuildAccessTokenResponse(tryGetSessionResponse.SessionUser, messageId)
+        => tryGetSessionResponse.IsSuccessWithSession()
+            ? BuildAccessTokenResponse(tryGetSessionResponse.SessionUser!, messageId)
             : BuildAccessTokenError(tryGetSessionResponse.Status, messageId);
 
     private static AuthAccessToken2 BuildAccessTokenResponse(SessionUser sessionUser, string messageId)
@@ -71,7 +70,7 @@ public class HandleAccessTokenRequestHandler : IRequestHandler<HandleAccessToken
                 "Authorising cookie invalid"),
             GetSessionStatus.DifferentOrigin => (AuthAccessTokenError2.InvalidOrigin, "Origin invalid",
                 "Requested origin differs from access service request"),
-            GetSessionStatus.MissingCookie => (AuthAccessTokenError2.MissingAspect, "Missing cookie",
+            GetSessionStatus.MissingCredentials => (AuthAccessTokenError2.MissingAspect, "Missing cookie",
                 "Authorising cookie not found"),
             GetSessionStatus.InvalidCookie => (AuthAccessTokenError2.InvalidAspect, "Invalid cookie",
                 "Authorising cookie invalid"),

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Probe/ProbeController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Probe/ProbeController.cs
@@ -1,0 +1,68 @@
+﻿using System.Net;
+using IIIF.Auth.V2;
+using IIIF.Presentation.V3.Strings;
+using IIIFAuth2.API.Features.Probe.Requests;
+using IIIFAuth2.API.Infrastructure.Web;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IIIFAuth2.API.Features.Probe;
+
+/// <summary>
+/// Controller for downstream/internal-only probe-service. This is used by other services to generate
+/// probe-service-response objects w/ status-code.
+/// </summary>
+/// <remarks>We don't use [ApiController] here as we always want to return a ProbeServiceResponse</remarks>
+[Route("[controller]")]
+public class ProbeController : AuthBaseController
+{
+    public ProbeController(IMediator mediator, ILogger<ProbeController> logger) : base(mediator, logger) 
+    {
+    }
+
+    /// <summary>
+    /// Generate a IIIF Probe Service Response by validating Bearer token  
+    /// </summary>
+    /// <param name="assetId">Id of DLCS asset to get probe service result for</param>
+    /// <param name="roles">Comma delimited list of roles that asset has</param>
+    [HttpGet]
+    [Route("{**assetId}")]
+    public async Task<IActionResult> ProbeService(
+        [FromRoute] string assetId,
+        [FromQuery] string roles,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(roles))
+                return GenerateErrorResult(HttpStatusCode.BadRequest, "Required roles query parameter missing");
+
+            var probeServiceRequest = new GetProbeServiceDescription(assetId, roles);
+            var probeServiceResult = await Mediator.Send(probeServiceRequest, cancellationToken);
+            return IIIFContent(probeServiceResult);
+        }
+        catch (FormatException fmtEx)
+        {
+            Logger.LogDebug(fmtEx, "Format exception processing request");
+            return GenerateErrorResult(HttpStatusCode.BadRequest, "Provided AssetId is invalid format");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unexpected error handling ProbeService request");
+            return GenerateErrorResult(HttpStatusCode.InternalServerError, "Unexpected error");
+        }
+    }
+    
+    private ContentResult GenerateErrorResult(HttpStatusCode statusCode, string note)
+    {
+        var heading = statusCode == HttpStatusCode.BadRequest ? "Bad Request" : "Unexpected Error";
+        var probeResult = new AuthProbeResult2
+        { 
+            Status = (int)statusCode,
+            Heading = new LanguageMap("en", heading),
+            Note = new LanguageMap("en", note),
+        };
+        
+        return IIIFContent(probeResult);
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Probe/ProbeController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Probe/ProbeController.cs
@@ -43,12 +43,12 @@ public class ProbeController : AuthBaseController
         }
         catch (FormatException fmtEx)
         {
-            Logger.LogDebug(fmtEx, "Format exception processing request");
+            Logger.LogDebug(fmtEx, "Format exception processing probe service request");
             return GenerateErrorResult(HttpStatusCode.BadRequest, "Provided AssetId is invalid format");
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Unexpected error handling ProbeService request");
+            Logger.LogError(ex, "Unexpected error handling probe service request");
             return GenerateErrorResult(HttpStatusCode.InternalServerError, "Unexpected error");
         }
     }

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Probe/Requests/GetProbeServiceDescription.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Probe/Requests/GetProbeServiceDescription.cs
@@ -44,7 +44,7 @@ public class GetServicesDescriptionHandler : IRequestHandler<GetProbeServiceDesc
 
     private static AuthProbeResult2 BuildProbeResultResponse(TryGetSessionResponse tryGetSessionResponse, IReadOnlyCollection<string> roles)
     {
-        var statusCode = GetStatusCode(tryGetSessionResponse, roles);
+        var statusCode = AccessStatusCodeHelpers.GetStatusCode(tryGetSessionResponse, roles);
         var probeService = new AuthProbeResult2
         { 
             Status = (int)statusCode, 
@@ -57,13 +57,6 @@ public class GetServicesDescriptionHandler : IRequestHandler<GetProbeServiceDesc
         if (note != null) probeService.Note = new LanguageMap("en", note);
 
         return probeService;
-    }
-
-    private static HttpStatusCode GetStatusCode(TryGetSessionResponse getSessionResponse, IReadOnlyCollection<string> roles)
-    {
-        if (!getSessionResponse.IsSuccessWithSession()) return HttpStatusCode.Unauthorized;
-        
-        return getSessionResponse.CanUserAccessAtLeastOneRole(roles) ? HttpStatusCode.OK : HttpStatusCode.Forbidden;
     }
 
     private static (string? Heading, string? Note) GetProperties(GetSessionStatus getSessionStatus, HttpStatusCode statusCode)

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Probe/Requests/GetProbeServiceDescription.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Probe/Requests/GetProbeServiceDescription.cs
@@ -1,0 +1,81 @@
+﻿using System.Net;
+using IIIF.Auth.V2;
+using IIIF.Presentation.V3.Strings;
+using IIIFAuth2.API.Infrastructure.Auth;
+using IIIFAuth2.API.Infrastructure.Auth.Models;
+using IIIFAuth2.API.Models.Domain;
+using MediatR;
+
+namespace IIIFAuth2.API.Features.Probe.Requests;
+
+/// <summary>
+/// Get a probe service response for specified roles
+/// </summary>
+public class GetProbeServiceDescription : IRequest<AuthProbeResult2>
+{
+    public AssetId AssetId { get; }
+    
+    public IReadOnlyCollection<string> Roles { get; }
+
+    public GetProbeServiceDescription(string assetId, string roles)
+    {
+        AssetId = AssetId.FromString(assetId);
+        Roles = roles.Split(",", StringSplitOptions.RemoveEmptyEntries);
+    }
+}
+
+public class GetServicesDescriptionHandler : IRequestHandler<GetProbeServiceDescription, AuthProbeResult2>
+{
+    private readonly SessionManagementService sessionManagementService;
+
+    public GetServicesDescriptionHandler(SessionManagementService sessionManagementService)
+    {
+        this.sessionManagementService = sessionManagementService;
+    }
+
+    public async Task<AuthProbeResult2> Handle(GetProbeServiceDescription request, CancellationToken cancellationToken)
+    {
+        var findSessionResponse =
+            await sessionManagementService.TryGetSessionUserForAccessToken(request.AssetId.Customer, cancellationToken);
+
+        var authProbeResult = BuildProbeResultResponse(findSessionResponse, request.Roles);
+        return authProbeResult;
+    }
+
+    private static AuthProbeResult2 BuildProbeResultResponse(TryGetSessionResponse tryGetSessionResponse, IReadOnlyCollection<string> roles)
+    {
+        var statusCode = GetStatusCode(tryGetSessionResponse, roles);
+        var probeService = new AuthProbeResult2
+        { 
+            Status = (int)statusCode, 
+        };
+
+        if (statusCode == HttpStatusCode.OK) return probeService;
+        
+        var (heading, note) = GetProperties(tryGetSessionResponse.Status, statusCode);
+        if (heading != null) probeService.Heading = new LanguageMap("en", heading);
+        if (note != null) probeService.Note = new LanguageMap("en", note);
+
+        return probeService;
+    }
+
+    private static HttpStatusCode GetStatusCode(TryGetSessionResponse getSessionResponse, IReadOnlyCollection<string> roles)
+    {
+        if (!getSessionResponse.IsSuccessWithSession()) return HttpStatusCode.Unauthorized;
+        
+        return getSessionResponse.CanUserAccessAtLeastOneRole(roles) ? HttpStatusCode.OK : HttpStatusCode.Forbidden;
+    }
+
+    private static (string? Heading, string? Note) GetProperties(GetSessionStatus getSessionStatus, HttpStatusCode statusCode)
+    {
+        if (statusCode == HttpStatusCode.Forbidden) return ("Forbidden", "Session does not have required roles");
+
+        return getSessionStatus switch
+        {
+            GetSessionStatus.MissingSession => ("Invalid credentials", "Authorising credentials invalid"),
+            GetSessionStatus.MissingCredentials => ("Missing credentials", "Authorising credentials not found"),
+            GetSessionStatus.ExpiredSession => ("Expired session", "Session has expired"),
+            _ => ("Unknown Error", "Unable to fulfil request")
+        };
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/VerifyAccess/Requests/TestAccessRequest.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/VerifyAccess/Requests/TestAccessRequest.cs
@@ -1,0 +1,42 @@
+﻿using System.Net;
+using IIIFAuth2.API.Infrastructure.Auth;
+using IIIFAuth2.API.Models.Domain;
+using MediatR;
+
+namespace IIIFAuth2.API.Features.VerifyAccess.Requests;
+
+/// <summary>
+/// Get an HttpStatusCode value indicating whether the current request has access to specified roles
+/// </summary>
+public class TestAccessRequest : IRequest<HttpStatusCode>
+{
+    public AssetId AssetId { get; }
+    
+    public IReadOnlyCollection<string> Roles { get; }
+
+    public TestAccessRequest(string assetId, string roles)
+    {
+        AssetId = AssetId.FromString(assetId);
+        Roles = roles.Split(",", StringSplitOptions.RemoveEmptyEntries);
+    }
+}
+
+public class GetAccessTestResultHandler : IRequestHandler<TestAccessRequest, HttpStatusCode>
+{
+    private readonly SessionManagementService sessionManagementService;
+
+    public GetAccessTestResultHandler(SessionManagementService sessionManagementService)
+    {
+        this.sessionManagementService = sessionManagementService;
+    }
+
+    public async Task<HttpStatusCode> Handle(TestAccessRequest request, CancellationToken cancellationToken)
+    {
+        var tryGetSessionResponse =
+            await sessionManagementService.TryGetSessionUserForCookie(request.AssetId.Customer, null,
+                cancellationToken);
+
+        var statusCode = AccessStatusCodeHelpers.GetStatusCode(tryGetSessionResponse, request.Roles);
+        return statusCode;
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/VerifyAccess/VerifyAccessController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/VerifyAccess/VerifyAccessController.cs
@@ -1,0 +1,36 @@
+﻿using IIIFAuth2.API.Features.VerifyAccess.Requests;
+using IIIFAuth2.API.Infrastructure.Web;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IIIFAuth2.API.Features.VerifyAccess;
+
+/// <summary>
+/// Controller for downstream/internal-only use by DLCS to validate whether request has access to specified resource.
+/// </summary>
+[Route("[controller]")]
+[ApiController]
+public class VerifyAccessController : AuthBaseController
+{
+    public VerifyAccessController(IMediator mediator, ILogger<VerifyAccessController> logger) : base(mediator, logger)
+    {
+    }
+
+    /// <summary>
+    /// Generate a status-code response by validating cookie associated with request  
+    /// </summary>
+    /// <param name="assetId">Id of DLCS asset to check access for</param>
+    /// <param name="roles">Comma delimited list of roles that asset has</param>
+    [HttpGet]
+    [Route("{**assetId}")]
+    public async Task<IActionResult> VerifyAccess(
+        [FromRoute] string assetId,
+        [FromQuery] string roles,
+        CancellationToken cancellationToken)
+        => await HandleRequest(async () =>
+        {
+            var testAccessRequest = new TestAccessRequest(assetId, roles);
+            var statusCode = await Mediator.Send(testAccessRequest, cancellationToken);
+            return StatusCode((int)statusCode);
+        });
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/IIIFAuth2.API.csproj
+++ b/src/IIIFAuth2/IIIFAuth2.API/IIIFAuth2.API.csproj
@@ -11,6 +11,7 @@
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
       <PackageReference Include="iiif-net" Version="0.2.1" />
       <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
+      <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.9">
         <PrivateAssets>all</PrivateAssets>

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AccessStatusCodeHelpers.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AccessStatusCodeHelpers.cs
@@ -1,0 +1,18 @@
+﻿using System.Net;
+using IIIFAuth2.API.Infrastructure.Auth.Models;
+
+namespace IIIFAuth2.API.Infrastructure.Auth;
+
+internal static class AccessStatusCodeHelpers
+{
+    /// <summary>
+    /// Get HttpStatusCode representing the result of access attempt for session in <see cref="TryGetSessionResponse"/>
+    /// to access specified roles
+    /// </summary>
+    public static HttpStatusCode GetStatusCode(TryGetSessionResponse getSessionResponse, IEnumerable<string> roles)
+    {
+        if (!getSessionResponse.IsSuccessWithSession()) return HttpStatusCode.Unauthorized;
+        
+        return getSessionResponse.CanUserAccessAtLeastOneRole(roles) ? HttpStatusCode.OK : HttpStatusCode.Forbidden;
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AuthAspectManager.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AuthAspectManager.cs
@@ -1,4 +1,5 @@
-﻿using IIIFAuth2.API.Data.Entities;
+﻿using System.Net.Http.Headers;
+using IIIFAuth2.API.Data.Entities;
 using IIIFAuth2.API.Settings;
 using IIIFAuth2.API.Utils;
 using Microsoft.Extensions.Options;
@@ -76,6 +77,21 @@ public class AuthAspectManager
                     Secure = true
                 });
         }
+    }
+
+    /// <summary>
+    /// Get the Id of provided access-token from Bearer token header
+    /// </summary>
+    public string? GetAccessToken()
+    {
+        const string bearerTokenScheme = "bearer";
+
+        var requestHeaders = httpContextAccessor.HttpContext.ThrowIfNull(nameof(httpContextAccessor.HttpContext))
+            .Request.Headers;
+        return AuthenticationHeaderValue.TryParse(requestHeaders.Authorization, out var parsed) &&
+               parsed.Scheme.Equals(bearerTokenScheme, StringComparison.InvariantCultureIgnoreCase)
+            ? parsed.Parameter
+            : null;
     }
 
     private IEnumerable<string> GetCookieDomainList(HttpContext httpContext)

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AuthAspectManager.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AuthAspectManager.cs
@@ -48,7 +48,7 @@ public class AuthAspectManager
     /// </summary>
     public string? GetCookieValueForCustomer(int customer)
     {
-        var httpContext = httpContextAccessor.HttpContext.ThrowIfNull(nameof(httpContextAccessor.HttpContext));
+        var httpContext = GetContext();
         var cookieKey = GetAuthCookieKey(authSettings.CookieNameFormat, customer);
         return httpContext.Request.Cookies.TryGetValue(cookieKey, out var cookieValue)
             ? cookieValue
@@ -60,7 +60,7 @@ public class AuthAspectManager
     /// </summary>
     public void IssueCookie(SessionUser sessionUser)
     {
-        var httpContext = httpContextAccessor.HttpContext.ThrowIfNull(nameof(httpContextAccessor.HttpContext));
+        var httpContext = GetContext();
         var domains = GetCookieDomainList(httpContext);
 
         var cookieValue = GetCookieValueForId(sessionUser.CookieId);
@@ -86,13 +86,15 @@ public class AuthAspectManager
     {
         const string bearerTokenScheme = "bearer";
 
-        var requestHeaders = httpContextAccessor.HttpContext.ThrowIfNull(nameof(httpContextAccessor.HttpContext))
-            .Request.Headers;
+        var requestHeaders = GetContext().Request.Headers;
         return AuthenticationHeaderValue.TryParse(requestHeaders.Authorization, out var parsed) &&
                parsed.Scheme.Equals(bearerTokenScheme, StringComparison.InvariantCultureIgnoreCase)
             ? parsed.Parameter
             : null;
     }
+
+    private HttpContext GetContext() =>
+        httpContextAccessor.HttpContext.ThrowIfNull(nameof(httpContextAccessor.HttpContext));
 
     private IEnumerable<string> GetCookieDomainList(HttpContext httpContext)
     {

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AuthAspectManager.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/AuthAspectManager.cs
@@ -9,13 +9,13 @@ namespace IIIFAuth2.API.Infrastructure.Auth;
 /// A collection of helper utils for dealing with auth cookies.
 /// </summary>
 /// <remarks>This is based on the original implementation for iiif auth 1.0 in Protagonist</remarks>
-public class AuthCookieManager
+public class AuthAspectManager
 {
     private readonly IHttpContextAccessor httpContextAccessor;
     private readonly AuthSettings authSettings;
     private const string CookiePrefix = "id=";
     
-    public AuthCookieManager(
+    public AuthAspectManager(
         IHttpContextAccessor httpContextAccessor,
         IOptions<AuthSettings> authSettings
         )

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/TryGetSessionResponse.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/TryGetSessionResponse.cs
@@ -29,9 +29,9 @@ public enum GetSessionStatus
     DifferentOrigin,
     
     /// <summary>
-    /// Cookie not found
+    /// Cookie or AccessToken not found
     /// </summary>
-    MissingCookie,
+    MissingCredentials,
     
     /// <summary>
     /// Cookie found but invalid

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/TryGetSessionResponse.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/TryGetSessionResponse.cs
@@ -1,4 +1,5 @@
 ﻿using IIIFAuth2.API.Data.Entities;
+using IIIFAuth2.API.Utils;
 
 namespace IIIFAuth2.API.Infrastructure.Auth.Models;
 
@@ -14,6 +15,18 @@ public static class TryGetSessionResponseX
     /// </summary>
     public static bool IsSuccessWithSession(this TryGetSessionResponse response)
         => response.Status == GetSessionStatus.Success && response.SessionUser != null;
+
+    /// <summary>
+    /// Check if current Session has access to at least one of the specified roles
+    /// </summary>
+    public static bool CanUserAccessAtLeastOneRole(this TryGetSessionResponse response,
+        IEnumerable<string> roles)
+    {
+        if (!response.IsSuccessWithSession()) return false;
+        
+        var sessionUserRoles = response.SessionUser?.Roles;
+        return !sessionUserRoles.IsNullOrEmpty() && sessionUserRoles.Intersect(roles).Any();
+    }
 }
 
 public enum GetSessionStatus

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/TryGetSessionResponse.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/TryGetSessionResponse.cs
@@ -7,6 +7,15 @@ namespace IIIFAuth2.API.Infrastructure.Auth.Models;
 /// </summary>
 public record TryGetSessionResponse(GetSessionStatus Status, SessionUser? SessionUser = null);
 
+public static class TryGetSessionResponseX
+{
+    /// <summary>
+    /// Check if status is 'Success' and SessionUser is present
+    /// </summary>
+    public static bool IsSuccessWithSession(this TryGetSessionResponse response)
+        => response.Status == GetSessionStatus.Success && response.SessionUser != null;
+}
+
 public enum GetSessionStatus
 {
     /// <summary>

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagementService.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagementService.cs
@@ -1,11 +1,15 @@
-﻿using IIIFAuth2.API.Data;
+﻿using System.Linq.Expressions;
+using IIIFAuth2.API.Data;
 using IIIFAuth2.API.Data.Entities;
 using IIIFAuth2.API.Infrastructure.Auth.Models;
 using IIIFAuth2.API.Models.Domain;
 using IIIFAuth2.API.Models.Result;
 using IIIFAuth2.API.Settings;
+using LazyCache;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Z.EntityFramework.Plus;
 
 namespace IIIFAuth2.API.Infrastructure.Auth;
 
@@ -16,17 +20,20 @@ public class SessionManagementService
 {
     private readonly AuthServicesContext dbContext;
     private readonly AuthAspectManager authAspectManager;
+    private readonly IAppCache appCache;
     private readonly ILogger<SessionManagementService> logger;
     private readonly AuthSettings authSettings;
 
     public SessionManagementService(
         AuthServicesContext dbContext,
         AuthAspectManager authAspectManager,
+        IAppCache appCache,
         IOptions<AuthSettings> authSettings,
         ILogger<SessionManagementService> logger)
     {
         this.dbContext = dbContext;
         this.authAspectManager = authAspectManager;
+        this.appCache = appCache;
         this.logger = logger;
         this.authSettings = authSettings.Value;
     }
@@ -118,7 +125,7 @@ public class SessionManagementService
         if (string.IsNullOrEmpty(cookieValue))
         {
             logger.LogDebug("Attempt to get cookie value for customer {CustomerId} but cookie not found", customerId);
-            return new TryGetSessionResponse(GetSessionStatus.MissingCookie);
+            return new TryGetSessionResponse(GetSessionStatus.MissingCredentials);
         }
 
         var cookieId = authAspectManager.GetCookieIdFromValue(cookieValue);
@@ -129,11 +136,36 @@ public class SessionManagementService
             return new TryGetSessionResponse(GetSessionStatus.InvalidCookie);
         }
 
-        var findSessionResponse = await GetRefreshedSession(customerId, cookieId, origin, cancellationToken);
-        if (findSessionResponse.Status != GetSessionStatus.Success) return findSessionResponse;
-        
-        // Re-issue the cookie to extend ttl
-        authAspectManager.IssueCookie(findSessionResponse.SessionUser!);
+        var findSessionResponse = await GetRefreshedSession(
+            su => su.CookieId == cookieId && su.Customer == customerId,
+            customerId,
+            cookieId,
+            origin,
+            cancellationToken);
+
+        return findSessionResponse;
+    }
+
+    /// <summary>
+    /// Attempt to load <see cref="SessionUser"/> for provided access-token. If found it may have expiry extended in
+    /// database and will issue cookie
+    /// </summary>
+    public async Task<TryGetSessionResponse> TryGetSessionUserForAccessToken(int customerId,
+        CancellationToken cancellationToken)
+    {
+        var accessToken = authAspectManager.GetAccessToken();
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            logger.LogDebug("Attempt to get session for customer {CustomerId} access-token but none found", customerId);
+            return new TryGetSessionResponse(GetSessionStatus.MissingCredentials);
+        }
+
+        var findSessionResponse = await GetRefreshedSession(
+            su => su.AccessToken == accessToken && su.Customer == customerId,
+            customerId,
+            accessToken,
+            cancellationToken: cancellationToken);
+
         return findSessionResponse;
     }
 
@@ -179,33 +211,65 @@ public class SessionManagementService
         }
     }
 
-    private async Task<TryGetSessionResponse> GetRefreshedSession(int customerId, string cookieId, string origin,
-        CancellationToken cancellationToken)
+    private async Task<TryGetSessionResponse> GetRefreshedSession(
+        Expression<Func<SessionUser, bool>> predicate,
+        int customerId,
+        string aspectValue,
+        string? origin = null,
+        CancellationToken cancellationToken = default)
+    {
+        var cacheKey = CacheKeys.AuthAspect(aspectValue, origin);
+        return await appCache.GetOrAddAsync(cacheKey, async entry =>
+        {
+            logger.LogTrace("Refreshing cached session for {AuthAspect} for {CustomerId}", aspectValue, customerId);
+            var tryGetSessionResponse =
+                await GetRefreshedSessionInternal(predicate, customerId, aspectValue, origin, cancellationToken);
+
+            if (tryGetSessionResponse.IsSuccessWithSession())
+            {
+                // Cache successful checks until just before next check time - overwriting default
+                var lastChecked = tryGetSessionResponse.SessionUser!.LastChecked ?? DateTime.UtcNow;
+                var entryAbsoluteExpiration = lastChecked.AddSeconds(authSettings.RefreshThreshold * 0.9);
+                logger.LogTrace("{AuthAspect} for {CustomerId} successfully fetched, caching until {CacheExpiry}",
+                    aspectValue, customerId, entryAbsoluteExpiration);
+                entry.AbsoluteExpiration = entryAbsoluteExpiration;
+            }
+
+            return tryGetSessionResponse;
+
+        }, new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(2) });
+    }
+
+    private async Task<TryGetSessionResponse> GetRefreshedSessionInternal(
+        Expression<Func<SessionUser, bool>> predicate,
+        int customerId,
+        string aspectValue,
+        string? origin = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
-            var session = await dbContext.SessionUsers
-                .SingleOrDefaultAsync(c => c.CookieId == cookieId && c.Customer == customerId, cancellationToken);
+            var session = await dbContext.SessionUsers.SingleOrDefaultAsync(predicate, cancellationToken);
 
             if (session == null)
             {
-                logger.LogInformation("UserSession for CookieId '{CookieId}' not found for customer {CustomerId}",
-                    cookieId, customerId);
+                logger.LogInformation("UserSession for aspect '{AuthAspect}' not found for customer {CustomerId}",
+                    aspectValue, customerId);
                 return new TryGetSessionResponse(GetSessionStatus.MissingSession);
             }
 
             if (session.Expires <= DateTime.UtcNow)
             {
-                logger.LogTrace("UserSession for CookieId '{CookieId}' for customer {Customer} expired", cookieId,
+                logger.LogTrace("UserSession for aspect '{AuthAspect}' for customer {Customer} expired", aspectValue,
                     customerId);
                 return new TryGetSessionResponse(GetSessionStatus.ExpiredSession);
             }
 
-            if (session.Origin != origin)
+            if (!string.IsNullOrEmpty(origin) && session.Origin != origin)
             {
                 logger.LogDebug(
-                    "UserSession for CookieId '{CookieId}' for customer {Customer} was for origin '{OriginalOrigin} but requested for '{NewOrigin}'",
-                    cookieId, customerId, session.Origin, origin);
+                    "UserSession for aspect '{AuthAspect}' for customer {Customer} was for origin '{OriginalOrigin} but requested for '{NewOrigin}'",
+                    aspectValue, customerId, session.Origin, origin);
                 return new TryGetSessionResponse(GetSessionStatus.DifferentOrigin);
             }
 
@@ -217,8 +281,11 @@ public class SessionManagementService
                 session.LastChecked = DateTime.UtcNow;
                 session.Expires = DateTime.UtcNow.AddSeconds(authSettings.SessionTtl);
                 await SaveChangesWithRowCountCheck("Extend user session", cancellationToken: cancellationToken);
+                QueryCacheManager.ExpireTag(CacheKeys.AuthAspect(aspectValue));
             }
 
+            // Re-issue the cookie to extend ttl
+            authAspectManager.IssueCookie(session);
             return new TryGetSessionResponse(GetSessionStatus.Success, session);
         }
         catch (Exception ex)
@@ -226,5 +293,5 @@ public class SessionManagementService
             logger.LogError(ex, "Unexpected error getting refresh token");
             return new TryGetSessionResponse(GetSessionStatus.UnknownError);
         }
-    } 
+    }
 }

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagementService.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagementService.cs
@@ -119,7 +119,7 @@ public class SessionManagementService
     /// Attempt to load <see cref="SessionUser"/> for provided CookieId. If found it may have expiry extended in
     /// database and will issue cookie
     /// </summary>
-    public async Task<TryGetSessionResponse> TryGetSessionUserForCookie(int customerId, string origin, CancellationToken cancellationToken)
+    public async Task<TryGetSessionResponse> TryGetSessionUserForCookie(int customerId, string? origin, CancellationToken cancellationToken)
     {
         var cookieValue = authAspectManager.GetCookieValueForCustomer(customerId);
         if (string.IsNullOrEmpty(cookieValue))

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagementService.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagementService.cs
@@ -9,7 +9,6 @@ using LazyCache;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using Z.EntityFramework.Plus;
 
 namespace IIIFAuth2.API.Infrastructure.Auth;
 
@@ -281,7 +280,6 @@ public class SessionManagementService
                 session.LastChecked = DateTime.UtcNow;
                 session.Expires = DateTime.UtcNow.AddSeconds(authSettings.SessionTtl);
                 await SaveChangesWithRowCountCheck("Extend user session", cancellationToken: cancellationToken);
-                QueryCacheManager.ExpireTag(CacheKeys.AuthAspect(aspectValue));
             }
 
             // Re-issue the cookie to extend ttl

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/ServiceCollectionX.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/ServiceCollectionX.cs
@@ -66,7 +66,7 @@ public static class ServiceCollectionX
     /// Add dependencies for handling auth requests
     /// </summary>
     public static IServiceCollection AddAuthServices(this IServiceCollection services)
-        => services.AddScoped<AuthCookieManager>()
+        => services.AddScoped<AuthAspectManager>()
             .AddScoped<RoleProviderService>()
             .AddScoped<ClickthroughRoleProviderHandler>()
             .AddScoped<SessionManagementService>()

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/ServiceCollectionX.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/ServiceCollectionX.cs
@@ -76,6 +76,14 @@ public static class ServiceCollectionX
                 _ => throw new ArgumentOutOfRangeException(nameof(roleProviderType), roleProviderType, null)
             });
 
+    /// <summary>
+    /// Add caching dependencies
+    /// </summary>
+    /// <remarks>
+    /// This adds LazyCache, Z.EntityFramework.Plus.EFCore caching is also used but there is no setup as default
+    /// MemoryCache is enough
+    /// </remarks>
+    public static IServiceCollection AddCaching(this IServiceCollection services) => services.AddLazyCache();
 }
 
 /// <summary>

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Web/AuthBaseController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Web/AuthBaseController.cs
@@ -1,4 +1,5 @@
-﻿using IIIF.Serialisation;
+﻿using IIIF;
+using IIIF.Serialisation;
 using IIIFAuth2.API.Models.Result;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -38,7 +39,7 @@ public abstract class AuthBaseController : Controller
                 return Problem(detail: result.ErrorMessage ?? "Entity not found", statusCode: 404, title: errorTitle);
             }
 
-            return Content(result.DescriptionResource.AsJson(), contentType);
+            return IIIFContent(result.DescriptionResource, contentType);
         });
     }
 
@@ -60,4 +61,7 @@ public abstract class AuthBaseController : Controller
             return Problem(detail: ex.Message, statusCode: 500, title: errorTitle ?? "Unexpected error");
         }
     }
+
+    protected ContentResult IIIFContent(JsonLdBase iiifModel, string contentType = "application/json")
+        => Content(iiifModel.AsJson(), contentType);
 }

--- a/src/IIIFAuth2/IIIFAuth2.API/Program.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Program.cs
@@ -33,6 +33,7 @@ try
         .AddAuthServicesContext(builder.Configuration)
         .AddAuthServicesHealthChecks()
         .AddMediatR(typeof(Program))
+        .AddCaching()
         .ConfigureAspnetMvc();
 
     var apiSettings = builder.Configuration.Get<ApiSettings>()!;


### PR DESCRIPTION
Resolves #2 

This PR adds 2 new endpoints, these are intended for internal use by other DLCS systems (for now Orchestrator only). See [Protagonist RFC 012 AuthService#Interactions](https://github.com/dlcs/protagonist/blob/main/docs/rfcs/012-auth-service.md#interactions) for more details.

First endpoint is a [probe-service](https://iiif.io/api/auth/2.0/#probe-service) as defined in IIIF Auth 2 spec. This always returns a 200 status code and a [probe-service-response](https://iiif.io/api/auth/2.0/#probe-service-response) object, using provided access-token to generate the result. The URL for this is `/probe/{assetId}?roles={roles}`.

The second endpoint is a not defined in the IIIF Auth 2 spec. It will return a status-code only, and is intended to be used by the Orchestrator as a quick _"does this session have access to this role?"_ check. This will return a 200/400/401/403/500 depending on circumstances. The URL for this is `/verifyaccess/{assetId}?roles={roles}`.

> Note that the 200 is empty but I've left it as 200 rather than 204 for convenience/ease as it's an internal-only call.

These are intended for internal use but I've not added any auth to them - I envisage us doing that at the infrastructure level rather than in code.

The following changes were made as part of this:
* I renamed `AuthCookieManager` to `AuthAspectManager` as it now handles cookie and bearer tokens.
* Added extension methods to `TryGetSessionResponse` to aid with various calls. The 2 above endpoints and the existing access-token-service share a few bits of logic in common that were easy to extract.
* `SessionManagementService` was refactored as checking userSession by bearer token and cookieId are very similar - preconditions and database query are the only differences.
* I added caching of the `TryGetSessionResponse`, the duration cached will be short but it is to alleviate a flood of requests when viewing tiles for example.