### PR TITLE
Add logout endpoint

### DIFF
--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessController.cs
@@ -70,4 +70,24 @@ public class AccessController : AuthBaseController
             return View("CloseWindow", errorMessage);
         });
     }
+
+    /// <summary>
+    /// IIIF Authorization logout service 
+    /// https://iiif.io/api/auth/2.0/#logout-service
+    /// </summary>
+    [HttpGet]
+    [Route("{customerId}/{accessServiceName}/logout")]
+    public async Task<IActionResult> AccessService(
+        [FromRoute] int customerId,
+        [FromRoute] string accessServiceName,
+        CancellationToken cancellationToken)
+    {
+        return await HandleRequest(async () =>
+        {
+            var logout = new HandleLogoutRequest(customerId, accessServiceName);
+            await Mediator.Send(logout, cancellationToken);
+
+            return NoContent();
+        });
+    }
 }

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/HandleLogoutRequest.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Requests/HandleLogoutRequest.cs
@@ -1,0 +1,35 @@
+﻿using IIIFAuth2.API.Infrastructure.Auth;
+using MediatR;
+
+namespace IIIFAuth2.API.Features.Access.Requests;
+
+/// <summary>
+/// Log specified user out of session for customer
+/// </summary>
+public class HandleLogoutRequest : IRequest<bool>
+{
+    public int CustomerId { get; }
+    public string AccessServiceName { get; }
+
+    public HandleLogoutRequest(int customerId, string accessServiceName)
+    {
+        CustomerId = customerId;
+        AccessServiceName = accessServiceName;
+    }
+}
+
+public class HandleLogoutRequestHandler : IRequestHandler<HandleLogoutRequest, bool>
+{
+    private readonly SessionCleaner sessionCleaner;
+
+    public HandleLogoutRequestHandler(SessionCleaner sessionCleaner)
+    {
+        this.sessionCleaner = sessionCleaner;
+    }
+    
+    public async Task<bool> Handle(HandleLogoutRequest request, CancellationToken cancellationToken)
+    {
+        var success = await sessionCleaner.LogoutUser(request.CustomerId, cancellationToken);
+        return success;
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionCleaner.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionCleaner.cs
@@ -1,0 +1,86 @@
+﻿using IIIFAuth2.API.Data;
+using IIIFAuth2.API.Data.Entities;
+using IIIFAuth2.API.Infrastructure.Auth.Models;
+using LazyCache;
+
+namespace IIIFAuth2.API.Infrastructure.Auth;
+
+/// <summary>
+/// Service for handling logging user out and cleaning up session
+/// </summary>
+public class SessionCleaner : SessionManagerBase
+{
+    private readonly IAppCache appCache;
+
+    public SessionCleaner(
+        AuthServicesContext dbContext,
+        AuthAspectManager authAspectManager,
+        IAppCache appCache,
+        ILogger<SessionManagementService> logger) : base(dbContext, authAspectManager, logger)
+    {
+        this.appCache = appCache;
+    }
+    
+    public async Task<bool> LogoutUser(int customerId, CancellationToken cancellationToken)
+    {
+        var sessionUser = await GetExistingSession(customerId, cancellationToken);
+        if (sessionUser == null) return false;
+        
+        Logger.LogDebug("Logging out session {SessionUserId} for {CustomerId}", sessionUser.Id, customerId);
+
+        var saveSuccess = await ExpireSessionInDatabase(cancellationToken, sessionUser);
+        
+        InvalidateCache(sessionUser);
+
+        AuthAspectManager.RemoveCookieFromResponse(sessionUser.Customer);
+        return saveSuccess;
+    }
+
+    private async Task<SessionUser?> GetExistingSession(int customerId, CancellationToken cancellationToken)
+    {
+        if (!TryGetCookieId(customerId, out var cookieId, out _)) return null;
+        
+        var findSessionResponse = await GetSessionUser(
+            su => su.CookieId == cookieId && su.Customer == customerId,
+            customerId,
+            cookieId,
+            null,
+            cancellationToken);
+
+        return findSessionResponse.IsSuccessWithSession() ? findSessionResponse.SessionUser : null;
+    } 
+    
+    private async Task<bool> ExpireSessionInDatabase(CancellationToken cancellationToken, SessionUser sessionUser)
+    {
+        try
+        {
+            sessionUser.LastChecked = DateTime.UtcNow;
+            sessionUser.Expires = DateTime.UtcNow.AddSeconds(-10);
+            await DbContext.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error saving expired SessionUser object {SessionUserId} for {CustomerId}",
+                sessionUser.Id, sessionUser.Customer);
+            return false;
+        }
+    }
+    
+    private void InvalidateCache(SessionUser sessionUser)
+    {
+        try
+        {
+            appCache.Remove(CacheKeys.AuthAspect(sessionUser.CookieId, sessionUser.Origin));
+            appCache.Remove(CacheKeys.AuthAspect(sessionUser.CookieId));
+            appCache.Remove(CacheKeys.AuthAspect(sessionUser.AccessToken, sessionUser.Origin));
+            appCache.Remove(CacheKeys.AuthAspect(sessionUser.AccessToken));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex,
+                "Error invalidating caches for expired SessionUser object {SessionUserId} for {CustomerId}",
+                sessionUser.Id, sessionUser.Customer);
+        }
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagementService.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagementService.cs
@@ -94,6 +94,7 @@ public class SessionManagementService : SessionManagerBase
             const int expectedRowCount = 2;
             var sessionUser = await CreateSessionAndIssueCookie(token.Customer, token.Roles, token.Origin,
                 "Create session from token", expectedRowCount, cancellationToken);
+            Logger.LogDebug("Successfully created Session for token: {Token}", roleProvisionToken);
             return ResultStatus<SessionUser>.Successful(sessionUser);
         }
         catch (DbUpdateConcurrencyException dbEx)

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagerBase.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/SessionManagerBase.cs
@@ -1,0 +1,95 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using IIIFAuth2.API.Data;
+using IIIFAuth2.API.Data.Entities;
+using IIIFAuth2.API.Infrastructure.Auth.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace IIIFAuth2.API.Infrastructure.Auth;
+
+/// <summary>
+/// Base class for services that interact with UserSessions 
+/// </summary>
+public abstract class SessionManagerBase
+{
+    protected readonly AuthServicesContext DbContext;
+    protected readonly AuthAspectManager AuthAspectManager;
+    protected readonly ILogger Logger;
+
+    protected SessionManagerBase(
+        AuthServicesContext dbContext,
+        AuthAspectManager authAspectManager,
+        ILogger logger)
+    {
+        DbContext = dbContext;
+        AuthAspectManager = authAspectManager;
+        Logger = logger;
+    }
+    
+    protected bool TryGetCookieId(int customerId, [NotNullWhen(true)] out string? cookieId,
+        [NotNullWhen(false)] out GetSessionStatus? status)
+    {
+        var cookieValue = AuthAspectManager.GetCookieValueForCustomer(customerId);
+        cookieId = null;
+        status = null;
+        if (string.IsNullOrEmpty(cookieValue))
+        {
+            Logger.LogDebug("Attempt to get cookie value for customer {CustomerId} but cookie not found", customerId);
+            status = GetSessionStatus.MissingCredentials;
+            return false;
+        }
+
+        cookieId = AuthAspectManager.GetCookieIdFromValue(cookieValue);
+        if (string.IsNullOrEmpty(cookieId))
+        {
+            Logger.LogDebug("Id not found in cookie '{CookieValue}' for customer {CustomerId}",
+                cookieValue, customerId);
+            status = GetSessionStatus.InvalidCookie;
+            return false;
+        }
+        
+        return true;
+    }
+    
+    protected async Task<TryGetSessionResponse> GetSessionUser(
+        Expression<Func<SessionUser, bool>> predicate,
+        int customerId,
+        string aspectValue,
+        string? origin = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var session = await DbContext.SessionUsers.SingleOrDefaultAsync(predicate, cancellationToken);
+
+            if (session == null)
+            {
+                Logger.LogInformation("UserSession for aspect '{AuthAspect}' not found for customer {CustomerId}",
+                    aspectValue, customerId);
+                return new TryGetSessionResponse(GetSessionStatus.MissingSession);
+            }
+
+            if (session.Expires <= DateTime.UtcNow)
+            {
+                Logger.LogTrace("UserSession for aspect '{AuthAspect}' for customer {Customer} expired", aspectValue,
+                    customerId);
+                return new TryGetSessionResponse(GetSessionStatus.ExpiredSession);
+            }
+
+            if (!string.IsNullOrEmpty(origin) && session.Origin != origin)
+            {
+                Logger.LogDebug(
+                    "UserSession for aspect '{AuthAspect}' for customer {Customer} was for origin '{OriginalOrigin} but requested for '{NewOrigin}'",
+                    aspectValue, customerId, session.Origin, origin);
+                return new TryGetSessionResponse(GetSessionStatus.DifferentOrigin);
+            }
+
+            return new TryGetSessionResponse(GetSessionStatus.Success, session);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unexpected error getting refresh token");
+            return new TryGetSessionResponse(GetSessionStatus.UnknownError);
+        }
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/ServiceCollectionX.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/ServiceCollectionX.cs
@@ -70,6 +70,7 @@ public static class ServiceCollectionX
             .AddScoped<RoleProviderService>()
             .AddScoped<ClickthroughRoleProviderHandler>()
             .AddScoped<SessionManagementService>()
+            .AddScoped<SessionCleaner>()
             .AddScoped<RoleProviderHandlerResolver>(provider => roleProviderType => roleProviderType switch
             {
                 RoleProviderType.Clickthrough => provider.GetRequiredService<ClickthroughRoleProviderHandler>(),


### PR DESCRIPTION
Resolves #20

Added [IIIF Authorization 2.0 Logout Service](https://iiif.io/api/auth/2.0/#logout-service) implementation at `GET {customerId}/{accessServiceName}/logout`.

The path takes `customerId` and `accessServiceName` but only uses the former - the `accessServiceName` will be handled at a later date once we handle multiple session/role-providers (in https://github.com/dlcs/iiif-auth-v2/issues/10#issuecomment-1662031478).

Upon logout the service will:
* Mark SessionUser as Expired in database
* Clear possible cached SessionUser values
* Issue a new expired cookie for same domains as real cookie

As part of this I refactored `SessionManagementService`, pulling out common parts to base class and adding `SessionCleaner` class.