### PR TITLE
Make origin value in AccessTokenResponse a valid JS string

### DIFF
--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessTokenServiceTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessTokenServiceTests.cs
@@ -306,9 +306,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
 
         if (!string.IsNullOrEmpty(origin))
         {
-            // Output origin is from a Uri object and may have trailing `/` appended so mimic here
-            var originToCheck = new Uri(origin);
-            elText.Should().Contain($"\"{originToCheck}\"", "origin should be a string");
+            elText.Should().Contain($"\"{origin}\"", "origin should be a string");
         }
     }
 

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessTokenServiceTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessTokenServiceTests.cs
@@ -66,7 +66,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        await ValidateResponse(response, expectedProfile: "missingAspect");
+        await ValidateResponse(response, expectedProfile: "missingAspect", origin: "http://localhost");
     }
     
     [Fact]
@@ -83,7 +83,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        await ValidateResponse(response, expectedProfile: "invalidAspect");
+        await ValidateResponse(response, expectedProfile: "invalidAspect", origin: "http://localhost");
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        await ValidateResponse(response, expectedProfile: "invalidAspect");
+        await ValidateResponse(response, expectedProfile: "invalidAspect", origin: "http://localhost");
     }
     
     [Fact]
@@ -122,7 +122,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        await ValidateResponse(response, expectedProfile: "invalidAspect");
+        await ValidateResponse(response, expectedProfile: "invalidAspect", origin: "http://localhost");
     }
     
     [Fact]
@@ -144,7 +144,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        await ValidateResponse(response, expectedProfile: "expiredAspect");
+        await ValidateResponse(response, expectedProfile: "expiredAspect", origin: "http://localhost");
     }
     
     [Fact]
@@ -166,7 +166,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        await ValidateResponse(response, expectedProfile: "invalidOrigin");
+        await ValidateResponse(response, expectedProfile: "invalidOrigin", origin: "http://whatever.here");
     }
 
     [Fact]
@@ -187,7 +187,7 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        await ValidateResponse(response, expectedAccessToken: "found-access-token");
+        await ValidateResponse(response, expectedAccessToken: "found-access-token", origin: "http://localhost");
     }
     
     [Fact]
@@ -281,26 +281,34 @@ public class AccessTokenServiceTests : IClassFixture<AuthWebApplicationFactory>
     }
 
     private static async Task ValidateResponse(HttpResponseMessage response, string? expectedProfile = null,
-        string? expectedAccessToken = null)
+        string? expectedAccessToken = null, string? origin = null)
     {
         var htmlParser = new HtmlParser();
         var document = htmlParser.ParseDocument(await response.Content.ReadAsStreamAsync());
         var el = document.QuerySelector("script") as IHtmlScriptElement;
 
+        var elText = el.Text;
         if (!string.IsNullOrEmpty(expectedProfile))
         {
-            el.Text.Should().Contain("\"type\": \"AuthAccessTokenError2\"",
+            elText.Should().Contain("\"type\": \"AuthAccessTokenError2\"",
                 "result is AuthAccessTokenError2");
-            el.Text.Should().Contain($"\"profile\": \"{expectedProfile}\"",
+            elText.Should().Contain($"\"profile\": \"{expectedProfile}\"",
                 $"expected profile is '{expectedProfile}'");
         }
 
         if (!string.IsNullOrEmpty(expectedAccessToken))
         {
-            el.Text.Should().Contain("\"type\": \"AuthAccessToken2\"",
+            elText.Should().Contain("\"type\": \"AuthAccessToken2\"",
                 "result is AuthAccessToken2");
-            el.Text.Should().Contain($"\"accessToken\": \"{expectedAccessToken}\"");
-            el.Text.Should().Contain("\"messageId\": \"12345\"");
+            elText.Should().Contain($"\"accessToken\": \"{expectedAccessToken}\"");
+            elText.Should().Contain("\"messageId\": \"12345\"");
+        }
+
+        if (!string.IsNullOrEmpty(origin))
+        {
+            // Output origin is from a Uri object and may have trailing `/` appended so mimic here
+            var originToCheck = new Uri(origin);
+            elText.Should().Contain($"\"{originToCheck}\"", "origin should be a string");
         }
     }
 

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Utils/UriXTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Utils/UriXTests.cs
@@ -1,0 +1,23 @@
+﻿using IIIFAuth2.API.Utils;
+
+namespace IIIFAuth2.API.Tests.Utils;
+
+public class UriXTests
+{
+    [Theory]
+    [InlineData("https://test.origin", "https://test.origin")]
+    [InlineData("https://test.origin/", "https://test.origin")]
+    [InlineData("http://test.origin:80/", "http://test.origin")]
+    [InlineData("https://test.origin:443/", "https://test.origin")]
+    [InlineData("https://test.origin:443/verify/", "https://test.origin")]
+    [InlineData("http://test.origin:8080/", "http://test.origin:8080")]
+    [InlineData("https://test.origin:8080/postal", "https://test.origin:8080")]
+    public void GetOrigin_ReturnsExpected(string uriInput, string expected)
+    {
+        var uri = new Uri(uriInput);
+
+        var actual = uri.GetOrigin();
+
+        actual.Should().Be(expected);
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/AccessTokenResponse.cshtml
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/AccessTokenResponse.cshtml
@@ -1,4 +1,5 @@
 @using IIIF.Serialisation
+@using IIIFAuth2.API.Utils
 @model (IIIF.JsonLdBase TokenResponse, Uri Origin)
 <!DOCTYPE html>
 
@@ -10,7 +11,7 @@
 <script>
     window.parent.postMessage(
       @Html.Raw(Model.TokenResponse.AsJson()),
-      "@Model.Origin"
+      "@Model.Origin?.GetOrigin()"
     );
 </script>
 </body>

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/AccessTokenResponse.cshtml
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/AccessTokenResponse.cshtml
@@ -10,7 +10,7 @@
 <script>
     window.parent.postMessage(
       @Html.Raw(Model.TokenResponse.AsJson()),
-      @Model.Origin
+      "@Model.Origin"
     );
 </script>
 </body>

--- a/src/IIIFAuth2/IIIFAuth2.API/Utils/UriX.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Utils/UriX.cs
@@ -1,0 +1,29 @@
+﻿using System.Text;
+
+namespace IIIFAuth2.API.Utils;
+
+public static class UriX
+{
+    private const string SchemeDelimiter = "://";
+    
+    /// <summary>
+    /// Get web-content origin, the scheme, host and port (if non-default)
+    /// </summary>
+    /// <remarks>See https://developer.mozilla.org/en-US/docs/Glossary/Origin</remarks>
+    public static string GetOrigin(this Uri uri)
+    {
+        var host = uri.Host;
+        var scheme = uri.Scheme;
+        var port = uri.IsDefaultPort ? string.Empty : $":{uri.Port}";
+
+        // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
+        var length = scheme.Length + SchemeDelimiter.Length + host.Length + port.Length;
+
+        return new StringBuilder(length)
+            .Append(scheme)
+            .Append(SchemeDelimiter)
+            .Append(host)
+            .Append(port)
+            .ToString();
+    }
+}


### PR DESCRIPTION
This will wraps the origin value in `"` to make it a valid string.output `"http://my.origin"` rather than `http://my.origin`. Also added a `ToOrigin()` extension method that outputs just the scheme, host and port (if non-default).

```
window.parent.postMessage(
  {
    "@context": "http://iiif.io/api/auth/2/context.json",
    "type": "AuthAccessToken2",
    "messageId": "1",
    "accessToken": "12345",
    "expiresIn": 999
  },
  "https://my.origin"
 );
```

rather than 
```
window.parent.postMessage(
  {
    "@context": "http://iiif.io/api/auth/2/context.json",
    "type": "AuthAccessToken2",
    "messageId": "1",
    "accessToken": "12345",
    "expiresIn": 999
  },
  https://my.origin
 );
```