### PR TITLE
Add customerId to gesture path

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -9,7 +9,7 @@ services:
     image: postgres:14
     hostname: postgres
     ports:
-      - "5433:5432"
+      - "5430:5432"
     volumes:
       - auth_postgres_data:/var/lib/postgresql/data
       - auth_postgres_data_backups:/backups

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Web/UrlPathProviderTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Web/UrlPathProviderTests.cs
@@ -30,6 +30,24 @@ public class UrlPathProviderTests
     }
     
     [Fact]
+    public void GetGesturePostbackRelativePath_HandlesNoConfiguredDefault_WithPathBase()
+    {
+        // Arrange
+        var gestureTemplates = new Dictionary<string, string>
+        {
+            [OtherHost] = "/access/specific-host"
+        };
+        var sut = GetSut(CurrentHost, gestureTemplates, "auth/v2/");
+        
+        // Act
+        var result = sut.GetGesturePostbackRelativePath(123);
+        
+        // Asset
+        result.IsAbsoluteUri.Should().BeFalse();
+        result.ToString().Should().Be("auth/v2/access/123/gesture");
+    }
+    
+    [Fact]
     public void GetGesturePostbackRelativePath_UsesConfiguredDefault()
     {
         // Arrange
@@ -67,7 +85,7 @@ public class UrlPathProviderTests
         result.ToString().Should().Be("/123/access/gesture");
     }
     
-    private UrlPathProvider GetSut(string host, Dictionary<string, string> gestureTemplates)
+    private UrlPathProvider GetSut(string host, Dictionary<string, string> gestureTemplates, string? pathBase = null)
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
@@ -77,7 +95,7 @@ public class UrlPathProviderTests
         A.CallTo(() => contextAccessor.HttpContext).Returns(context);
 
         var authSettings = new AuthSettings { GesturePathTemplateForDomain = gestureTemplates };
-        var apiSettings = Options.Create(new ApiSettings { Auth = authSettings });
+        var apiSettings = Options.Create(new ApiSettings { Auth = authSettings, PathBase = pathBase });
         
         return new UrlPathProvider(contextAccessor, apiSettings);
     }

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Web/UrlPathProviderTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Web/UrlPathProviderTests.cs
@@ -1,0 +1,84 @@
+﻿using FakeItEasy;
+using IIIFAuth2.API.Infrastructure.Web;
+using IIIFAuth2.API.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace IIIFAuth2.API.Tests.Infrastructure.Web;
+
+public class UrlPathProviderTests
+{
+    private const string CurrentHost = "dlcs.test.example";
+    private const string OtherHost = "dlcs.test.other";
+
+    [Fact]
+    public void GetGesturePostbackRelativePath_HandlesNoConfiguredDefault()
+    {
+        // Arrange
+        var gestureTemplates = new Dictionary<string, string>
+        {
+            [OtherHost] = "/access/specific-host"
+        };
+        var sut = GetSut(CurrentHost, gestureTemplates);
+        
+        // Act
+        var result = sut.GetGesturePostbackRelativePath(123);
+        
+        // Asset
+        result.IsAbsoluteUri.Should().BeFalse();
+        result.ToString().Should().Be("/access/123/gesture");
+    }
+    
+    [Fact]
+    public void GetGesturePostbackRelativePath_UsesConfiguredDefault()
+    {
+        // Arrange
+        var gestureTemplates = new Dictionary<string, string>
+        {
+            ["Default"] = "/access/other",
+            [OtherHost] = "/access/specific-host"
+        };
+        var sut = GetSut(CurrentHost, gestureTemplates);
+        
+        // Act
+        var result = sut.GetGesturePostbackRelativePath(123);
+        
+        // Asset
+        result.IsAbsoluteUri.Should().BeFalse();
+        result.ToString().Should().Be("/access/other");
+    }
+    
+    [Fact]
+    public void GetGesturePostbackRelativePath_UsesSpecifiedHost_IfFound()
+    {
+        // Arrange
+        var gestureTemplates = new Dictionary<string, string>
+        {
+            ["Default"] = "/access/other",
+            [CurrentHost] = "/{customerId}/access/gesture"
+        };
+        var sut = GetSut(CurrentHost, gestureTemplates);
+        
+        // Act
+        var result = sut.GetGesturePostbackRelativePath(123);
+        
+        // Asset
+        result.IsAbsoluteUri.Should().BeFalse();
+        result.ToString().Should().Be("/123/access/gesture");
+    }
+    
+    private UrlPathProvider GetSut(string host, Dictionary<string, string> gestureTemplates)
+    {
+        var context = new DefaultHttpContext();
+        var request = context.Request;
+        request.Host = new HostString(host);
+        request.Scheme = "https";
+        var contextAccessor = A.Fake<IHttpContextAccessor>();
+        A.CallTo(() => contextAccessor.HttpContext).Returns(context);
+
+        var authSettings = new AuthSettings { GesturePathTemplateForDomain = gestureTemplates };
+        var apiSettings = Options.Create(new ApiSettings { Auth = authSettings });
+        
+        return new UrlPathProvider(contextAccessor, apiSettings);
+    }
+}

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessServiceTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Integration/AccessServiceTests.cs
@@ -233,7 +233,7 @@ public class AccessServiceTests : IClassFixture<AuthWebApplicationFactory>
     public async Task SignificantGesture_Returns400_IfNoSingleUseToken()
     {
         // Arrange
-        const string path = "/access/gesture";
+        const string path = "/access/99/gesture";
             
         // Act
         var formContent = new FormUrlEncodedContent(new[]
@@ -250,7 +250,7 @@ public class AccessServiceTests : IClassFixture<AuthWebApplicationFactory>
     public async Task SignificantGesture_RendersWindowClose_WithError_IfTokenExpired()
     {
         // Arrange
-        const string path = "/access/gesture";
+        const string path = "/access/99/gesture";
         var expiredToken = ExpiringToken.GenerateNewToken(DateTime.UtcNow.AddHours(-1));
             
         // Act
@@ -270,7 +270,7 @@ public class AccessServiceTests : IClassFixture<AuthWebApplicationFactory>
     public async Task SignificantGesture_RendersWindowClose_WithError_IfTokenValidButNotInDatabase()
     {
         // Arrange
-        const string path = "/access/gesture";
+        const string path = "/access/99/gesture";
         var expiredToken = ExpiringToken.GenerateNewToken(DateTime.UtcNow.AddHours(1));
             
         // Act
@@ -290,7 +290,7 @@ public class AccessServiceTests : IClassFixture<AuthWebApplicationFactory>
     public async Task SignificantGesture_RendersWindowClose_WithError_IfTokenValidButUsed()
     {
         // Arrange
-        const string path = "/access/gesture";
+        const string path = "/access/99/gesture";
         var validToken = ExpiringToken.GenerateNewToken(DateTime.UtcNow.AddHours(1));
         await dbContext.RoleProvisionTokens.AddAsync(CreateToken(validToken, true, Array.Empty<string>()));
         await dbContext.SaveChangesAsync();
@@ -312,7 +312,7 @@ public class AccessServiceTests : IClassFixture<AuthWebApplicationFactory>
     public async Task SignificantGesture_CreatesSession_AndSetsCookie_AndMarksTokenAsUsed()
     {
         // Arrange
-        const string path = "/access/gesture";
+        const string path = "/access/99/gesture";
         var validToken = ExpiringToken.GenerateNewToken(DateTime.UtcNow.AddHours(1));
         var roles = new string[] { DatabaseFixture.ClickthroughRoleUri };
         var tokenEntity = await dbContext.RoleProvisionTokens.AddAsync(CreateToken(validToken, false, roles));

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Models/Converters/AccessServiceConverterTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Models/Converters/AccessServiceConverterTests.cs
@@ -226,7 +226,10 @@ public class AccessServiceConverterTests
         public Uri GetAccessServiceLogoutPath(AccessService accessService)
             => new($"http://test.example/access/{accessService.Name}/logout");
 
-        public Uri GetAccessTokenServicePath(int customer)
-            => new($"http://test.example/token/{customer}");
+        public Uri GetAccessTokenServicePath(int customerId)
+            => new($"http://test.example/token/{customerId}");
+
+        public Uri GetGesturePostbackRelativePath(int customerId)
+            => new($"/access/{customerId}/gesture", UriKind.Relative);
     }
 }

--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Utils/HttpRequestXTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Utils/HttpRequestXTests.cs
@@ -121,6 +121,26 @@ public class HttpRequestXTests
         // Assert
         result.Should().Be(expected);
     }
+    
+    [Fact]
+    public void GetDisplayUrl_WithPathBase_ReturnsFullUrl_WithoutQueryParam_WhenCalledWithDoNotIncludeHost()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "/v2/test";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl("/test", includeQueryParams: false, includeHost: false);
+        
+        // Assert
+        result.Should().Be(expected);
+    }
 
     [Theory]
     [InlineData("https://test.example")]

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessController.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/AccessController.cs
@@ -57,7 +57,7 @@ public class AccessController : AuthBaseController
     /// This is required for us to issue a cookie to user. 
     /// </summary>
     [HttpPost]
-    [Route("gesture")]
+    [Route("{customerId}/gesture")]
     public async Task<IActionResult> SignificantGesture(
         [FromForm] string singleUseToken,
         CancellationToken cancellationToken)

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/SignificantGesture.cshtml
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/SignificantGesture.cshtml
@@ -8,10 +8,9 @@
 </head>
 <body>
 <p>@Model.SignificantGestureMessage</p>
-@using (Html.BeginForm("SignificantGesture", "Access", new { customerId = Model.CustomerId}))
-{
+<form action="@Model.PostbackUri.ToString()" method="post">
     @Html.HiddenFor(m => m.SingleUseToken)
     <input type="submit">
-}
+</form>
 </body>
 </html>

--- a/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/SignificantGesture.cshtml
+++ b/src/IIIFAuth2/IIIFAuth2.API/Features/Access/Views/SignificantGesture.cshtml
@@ -8,7 +8,7 @@
 </head>
 <body>
 <p>@Model.SignificantGestureMessage</p>
-@using (Html.BeginForm("SignificantGesture", "Access"))
+@using (Html.BeginForm("SignificantGesture", "Access", new { customerId = Model.CustomerId}))
 {
     @Html.HiddenFor(m => m.SingleUseToken)
     <input type="submit">

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/SignificantGestureModel.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/SignificantGestureModel.cs
@@ -5,12 +5,14 @@ namespace IIIFAuth2.API.Infrastructure.Auth.Models;
 /// domain for a cookie to be issued, this captures a confirmation click to allow DLCS to issue a token that the browser
 /// will honour 
 /// </summary>
+/// <param name="CustomerId">CustomerId of asset being accessed</param>
 /// <param name="SignificantGestureTitle">Title of page</param>
 /// <param name="SignificantGestureMessage">Information message to display to user</param>
 /// <param name="SingleUseToken">
 /// Single use correlation id, from this we can lookup CustomerId, AccessServiceName + Roles to grant to user.
 /// </param>
 public record SignificantGestureModel(
+    int CustomerId,
     string SignificantGestureTitle, 
     string SignificantGestureMessage,
     string SingleUseToken);

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/SignificantGestureModel.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/Models/SignificantGestureModel.cs
@@ -5,14 +5,14 @@ namespace IIIFAuth2.API.Infrastructure.Auth.Models;
 /// domain for a cookie to be issued, this captures a confirmation click to allow DLCS to issue a token that the browser
 /// will honour 
 /// </summary>
-/// <param name="CustomerId">CustomerId of asset being accessed</param>
+/// <param name="PostbackUri">Relative Uri to post message back to. Can differ depending on hostname</param>
 /// <param name="SignificantGestureTitle">Title of page</param>
 /// <param name="SignificantGestureMessage">Information message to display to user</param>
 /// <param name="SingleUseToken">
 /// Single use correlation id, from this we can lookup CustomerId, AccessServiceName + Roles to grant to user.
 /// </param>
 public record SignificantGestureModel(
-    int CustomerId,
+    Uri PostbackUri,
     string SignificantGestureTitle, 
     string SignificantGestureMessage,
     string SingleUseToken);

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/ClickthroughRoleProviderHandler.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/ClickthroughRoleProviderHandler.cs
@@ -80,6 +80,7 @@ public class ClickthroughRoleProviderHandler : IRoleProviderHandler
         var expiringToken =
             await sessionManagementService.CreateRoleProvisionToken(customerId, roles, origin, cancellationToken);
         var gestureModel = new SignificantGestureModel(
+            customerId,
             configuration.GestureTitle ?? apiSettings.DefaultSignificantGestureTitle,
             configuration.GestureMessage ?? apiSettings.DefaultSignificantGestureMessage,
             expiringToken);

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/ClickthroughRoleProviderHandler.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/ClickthroughRoleProviderHandler.cs
@@ -1,6 +1,7 @@
 ﻿using IIIFAuth2.API.Data;
 using IIIFAuth2.API.Data.Entities;
 using IIIFAuth2.API.Infrastructure.Auth.Models;
+using IIIFAuth2.API.Infrastructure.Web;
 using IIIFAuth2.API.Models.Domain;
 using IIIFAuth2.API.Settings;
 using Microsoft.Extensions.Options;
@@ -16,16 +17,19 @@ public class ClickthroughRoleProviderHandler : IRoleProviderHandler
     private readonly SessionManagementService sessionManagementService;
     private readonly ILogger<ClickthroughRoleProviderHandler> logger;
     private readonly ApiSettings apiSettings;
+    private readonly IUrlPathProvider urlPathProvider;
 
     public ClickthroughRoleProviderHandler(
         AuthServicesContext dbContext,
         SessionManagementService sessionManagementService,
+        IUrlPathProvider urlPathProvider,
         IOptions<ApiSettings> apiOptions,
         ILogger<ClickthroughRoleProviderHandler> logger)
     {
         this.dbContext = dbContext;
         this.sessionManagementService = sessionManagementService;
         this.logger = logger;
+        this.urlPathProvider = urlPathProvider;
         apiSettings = apiOptions.Value;
     }
 
@@ -79,8 +83,9 @@ public class ClickthroughRoleProviderHandler : IRoleProviderHandler
     {
         var expiringToken =
             await sessionManagementService.CreateRoleProvisionToken(customerId, roles, origin, cancellationToken);
+        var relativePath = urlPathProvider.GetGesturePostbackRelativePath(customerId);
         var gestureModel = new SignificantGestureModel(
-            customerId,
+            relativePath,
             configuration.GestureTitle ?? apiSettings.DefaultSignificantGestureTitle,
             configuration.GestureMessage ?? apiSettings.DefaultSignificantGestureMessage,
             expiringToken);

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Web/UrlPathProvider.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Web/UrlPathProvider.cs
@@ -111,12 +111,20 @@ public class UrlPathProvider : IUrlPathProvider
     
     private string GetPopulatedTemplate(string host, int customerId)
     {
-        const string defaultPathTemplate = "/access/{customerId}/gesture";
-        var template = apiSettings.Auth.GesturePathTemplateForDomain.TryGetValue(host, out var pathTemplate)
-            ? pathTemplate
-            : defaultPathTemplate;
-
+        var template = GetTemplate(host);
         return template.Replace("{customerId}", customerId.ToString());
+    }
+    
+    private string GetTemplate(string host)
+    {
+        const string defaultPathTemplate = "/access/{customerId}/gesture";
+        const string defaultKey = "Default";
+
+        var pathTemplates = apiSettings.Auth.GesturePathTemplateForDomain;
+        
+        if (pathTemplates.TryGetValue(host, out var hostTemplate)) return hostTemplate;
+        if (pathTemplates.TryGetValue(defaultKey, out var pathTemplate)) return pathTemplate;
+        return defaultPathTemplate;
     }
 
     private string GetCurrentBaseUrl() =>

--- a/src/IIIFAuth2/IIIFAuth2.API/Settings/ApiSettings.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Settings/ApiSettings.cs
@@ -10,6 +10,8 @@ public class ApiSettings
     /// <remarks>Used to generate Probe request paths</remarks>
     public Uri OrchestratorRoot { get; set; } = null!;
 
+    public AuthSettings Auth { get; set; } = new();
+
     /// <summary>
     /// Fallback title for Significant Gesture view, if none specified by RoleProvider
     /// </summary>
@@ -39,4 +41,6 @@ public class AuthSettings
     /// </summary>
     /// <remarks>This avoids constant churn in db</remarks>
     public int RefreshThreshold { get; set; } = 120;
+
+    public Dictionary<string, string> GesturePathTemplateForDomain { get; set; } = new();
 }

--- a/src/IIIFAuth2/IIIFAuth2.API/Utils/HttpRequestX.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Utils/HttpRequestX.cs
@@ -5,21 +5,24 @@ namespace IIIFAuth2.API.Utils;
 public static class HttpRequestX
 {
     private const string SchemeDelimiter = "://";
-    
+
     /// <summary>
     /// Generate a full display URL, deriving values from specified HttpRequest
     /// </summary>
     /// <param name="request">HttpRequest to generate display URL for</param>
     /// <param name="path">Path to append to URL</param>
     /// <param name="includeQueryParams">If true, query params are included in path. Else they are omitted</param>
+    /// <param name="includeHost">If true, host and scheme are included in path. Else it is omitted</param>
     /// <returns>Full URL, including scheme, host, pathBase, path and queryString</returns>
     /// <remarks>
     /// based on Microsoft.AspNetCore.Http.Extensions.UriHelper.GetDisplayUrl(this HttpRequest request)
     /// </remarks>
-    public static string GetDisplayUrl(this HttpRequest request, string? path = null, bool includeQueryParams = true)
+    public static string GetDisplayUrl(this HttpRequest request, string? path = null, bool includeQueryParams = true,
+        bool includeHost = true)
     {
-        var host = request.Host.Value ?? string.Empty;
-        var scheme = request.Scheme ?? string.Empty;
+        var host = includeHost ? request.Host.Value : string.Empty;
+        var scheme = includeHost ? request.Scheme : string.Empty;
+        var schemeDelimiterToUse = includeHost ? SchemeDelimiter : string.Empty;
         var pathBase = request.PathBase.Value ?? string.Empty;
         var queryString = includeQueryParams
             ? request.QueryString.Value ?? string.Empty
@@ -27,12 +30,12 @@ public static class HttpRequestX
         var pathElement = path ?? string.Empty;
 
         // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
-        var length = scheme.Length + SchemeDelimiter.Length + host.Length
+        var length = scheme.Length + schemeDelimiterToUse.Length + host.Length
                      + pathBase.Length + pathElement.Length + queryString.Length;
 
         return new StringBuilder(length)
             .Append(scheme)
-            .Append(SchemeDelimiter)
+            .Append(schemeDelimiterToUse)
             .Append(host)
             .Append(pathBase)
             .Append(path)


### PR DESCRIPTION
The `customerId` value isn't currently used in code execution but keeps paths consistent and gives scope to use later if required

Gesture path was previously `/auth/v2/access/gesture`. 

This change makes it `/auth/v2/access/{customerId}/gesture` which keeps it aligned with other paths, which makes configuring bulk rewrite rules easier. E.g. 
* Access Service: `/auth/v2/access/{customerId}/{accessServiceName}`
* Logout Service: `/auth/v2/access/{customerId}/{accessServiceName}/logout`

Overriding the default value is done via appSettings rather than DB settings, this can be changed later if required. Note that the values configured in appSettings must contain the `pathBase` value, it felt wrong to force it to be picked up as the alternative route format may exclude it.