### PR TITLE
Support HS256 signed keys

### DIFF
--- a/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/RoleProvisioning/Oidc/Auth0ClientTests.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API.Tests/Infrastructure/Auth/RoleProvisioning/Oidc/Auth0ClientTests.cs
@@ -153,8 +153,7 @@ public class Auth0ClientTests
         
         // Assert
         A.CallTo(() => jwtTokenHandler.GetClaimsFromToken(idToken, jwksUri, "https://dlcs-dev.uk.auth0.com/", "test-id",
-                A<CancellationToken>._))
-            .MustHaveHappened();
+            "test-secret", A<CancellationToken>._)).MustHaveHappened();
     }
     
     [Fact]
@@ -172,7 +171,7 @@ public class Auth0ClientTests
             ClaimType = claimType,
         };
         A.CallTo(() => jwtTokenHandler.GetClaimsFromToken(idToken, A<Uri>._, A<string>._, A<string>._,
-                A<CancellationToken>._))
+                A<string>._, A<CancellationToken>._))
             .Returns(new ClaimsPrincipal(new ClaimsIdentity()));
         
         var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
@@ -207,7 +206,7 @@ public class Auth0ClientTests
             }
         };
         A.CallTo(() => jwtTokenHandler.GetClaimsFromToken(idToken, A<Uri>._, A<string>._, A<string>._,
-                A<CancellationToken>._))
+                A<string>._, A<CancellationToken>._))
             .Returns(new ClaimsPrincipal(new ClaimsIdentity(new []{new Claim(claimType, "foobar")})));
         
         var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/Oidc/Auth0Client.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/Oidc/Auth0Client.cs
@@ -87,7 +87,7 @@ public class Auth0Client : IAuth0Client
         
         var claimsPrincipal =
             await jwtTokenHandler.GetClaimsFromToken(auth0Token.IdToken, GetJwksUri(oidcConfiguration),
-                issuer, audience, cancellationToken);
+                issuer, audience, oidcConfiguration.ClientSecret, cancellationToken);
         if (claimsPrincipal == null) return Array.Empty<string>();
         
         var dlcsRoles = claimsConverter.GetDlcsRolesFromClaims(claimsPrincipal, oidcConfiguration);

--- a/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/Oidc/OidcRoleProviderHandler.cs
+++ b/src/IIIFAuth2/IIIFAuth2.API/Infrastructure/Auth/RoleProvisioning/Oidc/OidcRoleProviderHandler.cs
@@ -105,6 +105,12 @@ public class OidcRoleProviderHandler
                 var secretsJson = await secretsManagerCache.GetSecretString(secretName);
                 var secret = JsonSerializer.Deserialize<Secrets>(secretsJson, Options);
                 configuration.ClientSecret = secret?.ClientSecret ?? string.Empty;
+
+                if (string.IsNullOrWhiteSpace(configuration.ClientSecret))
+                {
+                    logger.LogWarning("Fetched secretsmanager secret {SecretName} for {AccessService} but got no value",
+                        secretName, accessServiceId);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
To date, auth0 testing has been done with tokens signed with `RS256` algorithm - the validation works by using signing keys from `/.well-known/jwks.json` endpoint (strongly typed as `X509SecurityKey`).

This PR adds support for `HS256` algorithm, where clientSecret is used to validate via `SymmetricSecurityKey` type. 

When validating we will always supply `SymmetricSecurityKey` and `X509SecurityKey`s - the `JwtSecurityTokenHandler` will select the appropriate method for validating.