### PR TITLE
Allow easier local running

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -13,13 +13,3 @@ services:
       - auth_postgres_data_backups:/backups
     env_file:
       - .env
-
-  nginx:
-    build:
-      context: ./nginx
-      dockerfile: Dockerfile
-    ports:
-      - "5040:443"
-      - "5039:80"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 volumes:
   auth_postgres_data: {}
   auth_postgres_data_backups: {}
@@ -10,7 +8,7 @@ services:
     ports:
       - "8014:80"
     environment:
-      - ConnectionStrings__PostgreSQLConnection=Server=postgres;Port=5432;Database=${POSTGRES_DB};User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};       
+      - ConnectionStrings__PostgreSQLConnection=Server=postgres;Port=5432;Database=${POSTGRES_DB};User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
 
   postgres:
     image: postgres:14

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,22 @@
+FROM nginx:alpine
+
+# Install OpenSSL (already included in alpine, but explicit for clarity)
+RUN apk add --no-cache openssl
+
+# Create SSL directory
+RUN mkdir -p /etc/nginx/ssl
+
+# Generate self-signed certificate
+RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout /etc/nginx/ssl/key.pem \
+    -out /etc/nginx/ssl/cert.pem \
+    -subj "/C=GB/ST=State/L=City/O=Organization/CN=localhost"
+
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Expose HTTP and HTTPS ports
+EXPOSE 80 443
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,74 @@
+user nginx;
+
+events {
+    worker_connections 1024;
+}
+http {
+    # Orchestrator on local machine (default from launchSettings)
+    upstream orchestrator {
+        server host.docker.internal:5013;
+    }
+
+    # Auth service running on local machine (default from launchSettings)
+    upstream auth_service {
+        server host.docker.internal:7149;
+    }
+
+    # HTTP server - redirect to HTTPS
+    server {
+        listen 80;
+        server_name localhost;
+
+        # Redirect all HTTP traffic to HTTPS
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name localhost;
+
+        # SSL certificate configuration
+        ssl_certificate /etc/nginx/ssl/cert.pem;
+        ssl_certificate_key /etc/nginx/ssl/key.pem;
+
+        # SSL settings for better security
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers on;
+
+        # Route /auth/v2/probe/* to host.docker.internal:5003
+        # This must come BEFORE the more general /auth/v2/* rule
+        location ~ ^/auth/v2/probe/ {
+            proxy_pass http://orchestrator;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route /auth/v2/* to host.docker.internal:7149
+        location ~ ^/auth/v2/ {
+            proxy_pass http://auth_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route everything else (/*) to host.docker.internal:5003
+        location / {
+            proxy_pass http://orchestrator;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Basic logging
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+    }
+}

--- a/scripts/sql/bootstrap.sql
+++ b/scripts/sql/bootstrap.sql
@@ -1,0 +1,28 @@
+-- Create a 'clickthrough' role
+-- This is an example config for Customer 7, creating role 'https://api.dlcs.digirati.io/customers/7/roles/clickthrough'
+begin transaction ;
+
+WITH
+    role_provider_id AS (SELECT gen_random_uuid() AS id),
+    access_service_id AS (SELECT gen_random_uuid() AS id),
+    -- create a role provder
+    insert_role_provider AS (
+        INSERT INTO role_providers (id, configuration)
+            SELECT id, '{"default": {"config": "Clickthrough"}}'
+            FROM role_provider_id
+            RETURNING *
+    ),
+    -- and an access service
+    insert_access_service AS (
+        INSERT INTO access_services (id, customer, role_provider_id, name, profile, label, heading, note, confirm_label, access_token_error_heading, access_token_error_note, logout_label)
+            SELECT access_service_id.id, 7, role_provider_id.id, 'clickthrough', 'active', '{"en":["Sample clickthrough label"]}', '{"en":["Sample clickthrough note"]}', '{"en": ["<p>This is a test of clickthrough via IIIF Authorization Flow 2.0</p>"]}', '{"en":["Accept and Open"]}', null, null, '{"en":["Log out of session"]}'
+            FROM role_provider_id, access_service_id
+            RETURNING *
+    )
+-- and finally a role
+INSERT INTO roles (id, customer, access_service_id, name)
+SELECT 'https://api.dlcs.digirati.io/customers/7/roles/clickthrough', 7, id, 'clickthrough'
+FROM access_service_id;
+
+rollback ;
+commit ;


### PR DESCRIPTION
orchestrator and iiif-auth-v2 must run on same domain so to ease local debugging added an nginx container.

Added sample SQL script to setup clickthrough role.

This still requires that Orchestrator and associated services (image-server etc) are running locally, which can be achieved via [orchestrator compose](https://github.com/dlcs/protagonist/blob/develop/compose/docker-compose.orchestrator.yml) file in Protagonist.